### PR TITLE
feat: change auto-refresh interval with pause/play toggle

### DIFF
--- a/frontend/src/lib/components/graph/NetworkGraph.svelte
+++ b/frontend/src/lib/components/graph/NetworkGraph.svelte
@@ -106,11 +106,9 @@
 	const flowNodesStore = writable<Node[]>([]);
 	const flowEdgesStore = writable<Edge[]>([]);
 
-	// Track topology (node IDs only — edge churn should not trigger full re-layout)
+	// Track topology (node IDs + edge connections, excluding traffic volumes)
 	let lastTopologyKey = '';
 	let isLayouting = $state(false);
-	let hasInitialLayout = false;
-	let layoutVersion = 0;
 	let layoutDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 	// Store references to flow functions (set by child component)
@@ -159,19 +157,20 @@
 	// Track edge traffic data for style-only updates
 	let lastEdgeKey = '';
 
-	// Build a topology key from node IDs only — edge churn (new flows appearing/disappearing)
-	// should not trigger expensive full re-layouts
-	function buildTopologyKey(nodeList: NetworkNodeType[]): string {
-		return nodeList.map((n) => n.id).sort().join(',');
+	// Build a topology key from node IDs + edge connections (ignoring traffic volumes)
+	function buildTopologyKey(nodeList: NetworkNodeType[], edgeList: NetworkLink[]): string {
+		const nodesPart = nodeList.map((n) => n.id).sort().join(',');
+		const edgesPart = edgeList.map((e) => `${e.source}->${e.target}`).sort().join(',');
+		return `${nodesPart}|${edgesPart}`;
 	}
 
 	// Update stores and apply layout when props change
 	$effect(() => {
-		const currentTopologyKey = buildTopologyKey(nodes);
+		const currentTopologyKey = buildTopologyKey(nodes, edges);
 		const currentEdgeKey = edges.map((e) => `${e.id}:${e.totalBytes}`).sort().join(',');
 
 		if (currentTopologyKey !== lastTopologyKey && nodes.length > 0) {
-			// Node set changed - debounce re-layout to batch rapid changes
+			// Topology changed - debounce re-layout to batch rapid changes
 			lastTopologyKey = currentTopologyKey;
 			lastEdgeKey = currentEdgeKey;
 			originalEdges = edges;
@@ -182,54 +181,22 @@
 				layoutNodes();
 			}, 100);
 		} else if (currentEdgeKey !== lastEdgeKey && !isLayouting) {
-			// Only traffic volumes or edge set changed - update edges without re-layout
+			// Only traffic volumes changed - update edge styles without re-layout
 			lastEdgeKey = currentEdgeKey;
 			originalEdges = edges;
 			const highlighted = $highlightedEdgeIds;
 			const isSelectionActive = $hasSelection;
 
-			// Sync edges: add new edges, remove stale ones, update styles
-			const newEdgeMap = new Map(edges.map((e) => [e.id, e]));
+			const edgeLookup = new Map(edges.map((e) => [e.id, e]));
 			flowEdgesStore.update((currentEdges) => {
-				const existingIds = new Set(currentEdges.map((e) => e.id));
-				// Update existing edges + keep only edges that still exist
-				const updated = currentEdges
-					.filter((flowEdge) => newEdgeMap.has(flowEdge.id))
-					.map((flowEdge) => {
-						const originalEdge = newEdgeMap.get(flowEdge.id)!;
-						const dimmed = isSelectionActive && !highlighted.has(flowEdge.id);
-						return {
-							...flowEdge,
-							source: originalEdge.source,
-							target: originalEdge.target,
-							style: getEdgeStyle(originalEdge, dimmed)
-						};
-					});
-				// Add new edges
-				for (const [id, edge] of newEdgeMap) {
-					if (!existingIds.has(id)) {
-						const dimmed = isSelectionActive && !highlighted.has(id);
-						updated.push({
-							id: edge.id,
-							source: edge.source,
-							target: edge.target,
-							type: 'default',
-							style: getEdgeStyle(edge, dimmed)
-						});
-					}
-				}
-				return updated;
-			});
+				return currentEdges.map((flowEdge) => {
+					const originalEdge = edgeLookup.get(flowEdge.id);
+					if (!originalEdge) return flowEdge;
 
-			// Also update node data (traffic totals etc.) without changing positions
-			const nodeDataMap = new Map(nodes.map((n) => [n.id, n]));
-			flowNodesStore.update((currentNodes) => {
-				return currentNodes.map((flowNode) => {
-					const freshData = nodeDataMap.get(flowNode.id);
-					if (!freshData) return flowNode;
+					const dimmed = isSelectionActive && !highlighted.has(flowEdge.id);
 					return {
-						...flowNode,
-						data: { label: freshData.displayName, ...freshData }
+						...flowEdge,
+						style: getEdgeStyle(originalEdge, dimmed)
 					};
 				});
 			});
@@ -303,33 +270,18 @@
 	async function layoutNodes() {
 		if (isLayouting) return;
 		isLayouting = true;
-		const thisVersion = ++layoutVersion;
 
 		try {
-			// Capture existing node state so we can preserve positions and measured dimensions
-			const existingNodes = new Map<string, Node>();
-			get(flowNodesStore).forEach((n) => {
-				existingNodes.set(n.id, n);
-			});
-			const isInitial = !hasInitialLayout;
-
-			// Convert to Svelte Flow format, preserving measured dimensions from existing nodes
-			const flowNodes: Node[] = nodes.map((node) => {
-				const existing = existingNodes.get(node.id);
-				return {
-					id: node.id,
-					type: 'network',
-					position: existing?.position ?? { x: 0, y: 0 },
-					// Preserve measured dimensions so MiniMap continues to render nodes
-					...(existing?.measured ? { measured: existing.measured } : {}),
-					...(existing?.width != null ? { width: existing.width } : {}),
-					...(existing?.height != null ? { height: existing.height } : {}),
-					data: {
-						label: node.displayName,
-						...node
-					}
-				};
-			});
+			// Convert to Svelte Flow format
+			const flowNodes: Node[] = nodes.map((node) => ({
+				id: node.id,
+				type: 'network',
+				position: { x: 0, y: 0 },
+				data: {
+					label: node.displayName,
+					...node
+				}
+			}));
 
 			const flowEdges: Edge[] = edges.map((edge) => ({
 				id: edge.id,
@@ -339,97 +291,32 @@
 				style: getEdgeStyle(edge)
 			}));
 
-			if (isInitial) {
-				// First layout: full ELK layout + fitView
-				const { nodes: layoutedNodes, edges: layoutedEdges } = await applyElkLayout(
-					flowNodes,
-					flowEdges,
-					{ algorithm: 'layered', nodeSpacing: 150 }
-				);
+			// Apply ELK layout
+			const { nodes: layoutedNodes, edges: layoutedEdges } = await applyElkLayout(
+				flowNodes,
+				flowEdges,
+				{ algorithm: 'layered', nodeSpacing: 150 }
+			);
 
-				if (thisVersion !== layoutVersion) return; // stale layout, discard
+			flowNodesStore.set(layoutedNodes);
 
-				flowNodesStore.set(layoutedNodes);
-				flowEdgesStore.set(layoutedEdges);
-				hasInitialLayout = true;
-			} else {
-				// Subsequent refresh: preserve existing node positions, place new nodes
-				const newNodeIds = nodes
-					.filter((n) => !existingNodes.has(n.id))
-					.map((n) => n.id);
-
-				if (newNodeIds.length > 0 && newNodeIds.length < nodes.length * 0.5) {
-					// Minor topology change: run ELK for full graph but then
-					// restore positions for existing nodes (only use ELK for new ones)
-					const { nodes: layoutedNodes, edges: layoutedEdges } = await applyElkLayout(
-						flowNodes,
-						flowEdges,
-						{ algorithm: 'layered', nodeSpacing: 150 }
-					);
-
-					if (thisVersion !== layoutVersion) return;
-
-					const newNodeSet = new Set(newNodeIds);
-					const mergedNodes = layoutedNodes.map((ln) => {
-						if (newNodeSet.has(ln.id)) return ln; // new node gets ELK position
-						const existing = existingNodes.get(ln.id);
-						if (existing) {
-							return {
-								...ln,
-								position: existing.position,
-								...(existing.measured ? { measured: existing.measured } : {}),
-								...(existing.width != null ? { width: existing.width } : {}),
-								...(existing.height != null ? { height: existing.height } : {})
-							};
-						}
-						return ln;
-					});
-
-					flowNodesStore.set(mergedNodes);
-					flowEdgesStore.set(layoutedEdges);
-				} else if (newNodeIds.length >= nodes.length * 0.5) {
-					// Major topology change (>50% new): full re-layout
-					const { nodes: layoutedNodes, edges: layoutedEdges } = await applyElkLayout(
-						flowNodes,
-						flowEdges,
-						{ algorithm: 'layered', nodeSpacing: 150 }
-					);
-
-					if (thisVersion !== layoutVersion) return;
-
-					flowNodesStore.set(layoutedNodes);
-					flowEdgesStore.set(layoutedEdges);
-				} else {
-					// No new nodes, just nodes were removed — update in place
-					if (thisVersion !== layoutVersion) return;
-
-					flowNodesStore.set(flowNodes);
-					flowEdgesStore.set(flowEdges);
-				}
-			}
+			flowEdgesStore.set(layoutedEdges);
 		} catch (error) {
-			if (thisVersion !== layoutVersion) return;
 			console.error('Layout failed:', error);
 			// Fallback: just set nodes with grid positions
 			const cols = Math.ceil(Math.sqrt(nodes.length));
-			const flowNodes: Node[] = nodes.map((node, index) => {
-				const existing = get(flowNodesStore).find((n) => n.id === node.id);
-				return {
-					id: node.id,
-					type: 'network',
-					position: {
-						x: (index % cols) * 300 + 50,
-						y: Math.floor(index / cols) * 180 + 50
-					},
-					...(existing?.measured ? { measured: existing.measured } : {}),
-					...(existing?.width != null ? { width: existing.width } : {}),
-					...(existing?.height != null ? { height: existing.height } : {}),
-					data: {
-						label: node.displayName,
-						...node
-					}
-				};
-			});
+			const flowNodes: Node[] = nodes.map((node, index) => ({
+				id: node.id,
+				type: 'network',
+				position: {
+					x: (index % cols) * 300 + 50,
+					y: Math.floor(index / cols) * 180 + 50
+				},
+				data: {
+					label: node.displayName,
+					...node
+				}
+			}));
 
 			const flowEdges: Edge[] = edges.map((edge) => ({
 				id: edge.id,
@@ -441,11 +328,8 @@
 
 			flowNodesStore.set(flowNodes);
 			flowEdgesStore.set(flowEdges);
-			if (!hasInitialLayout) hasInitialLayout = true;
 		} finally {
-			if (thisVersion === layoutVersion) {
-				isLayouting = false;
-			}
+			isLayouting = false;
 		}
 	}
 
@@ -485,7 +369,7 @@
 		if (fitViewRef) fitViewRef({ duration: 400, padding: 0.1 });
 	}
 
-	// Capture flow instance when mounted, only fitView on initial layout
+	// Capture flow instance when mounted, defer fitView for smoother rendering
 	function captureFlowInstance() {
 		const { fitBounds, fitView } = useSvelteFlow();
 		fitBoundsRef = fitBounds;
@@ -496,8 +380,8 @@
 	}
 </script>
 
-<div class="h-full w-full relative">
-	{#if isLayouting && !hasInitialLayout}
+<div class="h-full w-full">
+	{#if isLayouting}
 		<div class="flex h-full items-center justify-center">
 			<div class="text-muted-foreground">Calculating layout...</div>
 		</div>
@@ -532,12 +416,5 @@
 				/>
 			</SvelteFlow>
 		</SvelteFlowProvider>
-	{/if}
-
-	<!-- Layout update indicator (shown as overlay, does NOT unmount the graph) -->
-	{#if isLayouting && hasInitialLayout}
-		<div class="absolute top-2 left-1/2 -translate-x-1/2 z-10 rounded-md bg-card/90 border border-border px-3 py-1.5 text-xs text-muted-foreground shadow-sm">
-			Updating layout...
-		</div>
 	{/if}
 </div>

--- a/frontend/src/lib/components/graph/NetworkGraph.svelte
+++ b/frontend/src/lib/components/graph/NetworkGraph.svelte
@@ -106,9 +106,11 @@
 	const flowNodesStore = writable<Node[]>([]);
 	const flowEdgesStore = writable<Edge[]>([]);
 
-	// Track topology (node IDs + edge connections, excluding traffic volumes)
+	// Track topology (node IDs only — edge churn should not trigger full re-layout)
 	let lastTopologyKey = '';
 	let isLayouting = $state(false);
+	let hasInitialLayout = false;
+	let layoutVersion = 0;
 	let layoutDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 	// Store references to flow functions (set by child component)
@@ -157,20 +159,19 @@
 	// Track edge traffic data for style-only updates
 	let lastEdgeKey = '';
 
-	// Build a topology key from node IDs + edge connections (ignoring traffic volumes)
-	function buildTopologyKey(nodeList: NetworkNodeType[], edgeList: NetworkLink[]): string {
-		const nodesPart = nodeList.map((n) => n.id).sort().join(',');
-		const edgesPart = edgeList.map((e) => `${e.source}->${e.target}`).sort().join(',');
-		return `${nodesPart}|${edgesPart}`;
+	// Build a topology key from node IDs only — edge churn (new flows appearing/disappearing)
+	// should not trigger expensive full re-layouts
+	function buildTopologyKey(nodeList: NetworkNodeType[]): string {
+		return nodeList.map((n) => n.id).sort().join(',');
 	}
 
 	// Update stores and apply layout when props change
 	$effect(() => {
-		const currentTopologyKey = buildTopologyKey(nodes, edges);
+		const currentTopologyKey = buildTopologyKey(nodes);
 		const currentEdgeKey = edges.map((e) => `${e.id}:${e.totalBytes}`).sort().join(',');
 
 		if (currentTopologyKey !== lastTopologyKey && nodes.length > 0) {
-			// Topology changed - debounce re-layout to batch rapid changes
+			// Node set changed - debounce re-layout to batch rapid changes
 			lastTopologyKey = currentTopologyKey;
 			lastEdgeKey = currentEdgeKey;
 			originalEdges = edges;
@@ -181,22 +182,54 @@
 				layoutNodes();
 			}, 100);
 		} else if (currentEdgeKey !== lastEdgeKey && !isLayouting) {
-			// Only traffic volumes changed - update edge styles without re-layout
+			// Only traffic volumes or edge set changed - update edges without re-layout
 			lastEdgeKey = currentEdgeKey;
 			originalEdges = edges;
 			const highlighted = $highlightedEdgeIds;
 			const isSelectionActive = $hasSelection;
 
-			const edgeLookup = new Map(edges.map((e) => [e.id, e]));
+			// Sync edges: add new edges, remove stale ones, update styles
+			const newEdgeMap = new Map(edges.map((e) => [e.id, e]));
 			flowEdgesStore.update((currentEdges) => {
-				return currentEdges.map((flowEdge) => {
-					const originalEdge = edgeLookup.get(flowEdge.id);
-					if (!originalEdge) return flowEdge;
+				const existingIds = new Set(currentEdges.map((e) => e.id));
+				// Update existing edges + keep only edges that still exist
+				const updated = currentEdges
+					.filter((flowEdge) => newEdgeMap.has(flowEdge.id))
+					.map((flowEdge) => {
+						const originalEdge = newEdgeMap.get(flowEdge.id)!;
+						const dimmed = isSelectionActive && !highlighted.has(flowEdge.id);
+						return {
+							...flowEdge,
+							source: originalEdge.source,
+							target: originalEdge.target,
+							style: getEdgeStyle(originalEdge, dimmed)
+						};
+					});
+				// Add new edges
+				for (const [id, edge] of newEdgeMap) {
+					if (!existingIds.has(id)) {
+						const dimmed = isSelectionActive && !highlighted.has(id);
+						updated.push({
+							id: edge.id,
+							source: edge.source,
+							target: edge.target,
+							type: 'default',
+							style: getEdgeStyle(edge, dimmed)
+						});
+					}
+				}
+				return updated;
+			});
 
-					const dimmed = isSelectionActive && !highlighted.has(flowEdge.id);
+			// Also update node data (traffic totals etc.) without changing positions
+			const nodeDataMap = new Map(nodes.map((n) => [n.id, n]));
+			flowNodesStore.update((currentNodes) => {
+				return currentNodes.map((flowNode) => {
+					const freshData = nodeDataMap.get(flowNode.id);
+					if (!freshData) return flowNode;
 					return {
-						...flowEdge,
-						style: getEdgeStyle(originalEdge, dimmed)
+						...flowNode,
+						data: { label: freshData.displayName, ...freshData }
 					};
 				});
 			});
@@ -270,13 +303,21 @@
 	async function layoutNodes() {
 		if (isLayouting) return;
 		isLayouting = true;
+		const thisVersion = ++layoutVersion;
 
 		try {
+			// Capture existing positions so we can preserve them on subsequent refreshes
+			const existingPositions = new Map<string, { x: number; y: number }>();
+			get(flowNodesStore).forEach((n) => {
+				existingPositions.set(n.id, { x: n.position.x, y: n.position.y });
+			});
+			const isInitial = !hasInitialLayout;
+
 			// Convert to Svelte Flow format
 			const flowNodes: Node[] = nodes.map((node) => ({
 				id: node.id,
 				type: 'network',
-				position: { x: 0, y: 0 },
+				position: existingPositions.get(node.id) ?? { x: 0, y: 0 },
 				data: {
 					label: node.displayName,
 					...node
@@ -291,17 +332,68 @@
 				style: getEdgeStyle(edge)
 			}));
 
-			// Apply ELK layout
-			const { nodes: layoutedNodes, edges: layoutedEdges } = await applyElkLayout(
-				flowNodes,
-				flowEdges,
-				{ algorithm: 'layered', nodeSpacing: 150 }
-			);
+			if (isInitial) {
+				// First layout: full ELK layout + fitView
+				const { nodes: layoutedNodes, edges: layoutedEdges } = await applyElkLayout(
+					flowNodes,
+					flowEdges,
+					{ algorithm: 'layered', nodeSpacing: 150 }
+				);
 
-			flowNodesStore.set(layoutedNodes);
+				if (thisVersion !== layoutVersion) return; // stale layout, discard
 
-			flowEdgesStore.set(layoutedEdges);
+				flowNodesStore.set(layoutedNodes);
+				flowEdgesStore.set(layoutedEdges);
+				hasInitialLayout = true;
+			} else {
+				// Subsequent refresh: preserve existing node positions, place new nodes
+				const newNodeIds = nodes
+					.filter((n) => !existingPositions.has(n.id))
+					.map((n) => n.id);
+
+				if (newNodeIds.length > 0 && newNodeIds.length < nodes.length * 0.5) {
+					// Minor topology change: run ELK for full graph but then
+					// restore positions for existing nodes (only use ELK for new ones)
+					const { nodes: layoutedNodes, edges: layoutedEdges } = await applyElkLayout(
+						flowNodes,
+						flowEdges,
+						{ algorithm: 'layered', nodeSpacing: 150 }
+					);
+
+					if (thisVersion !== layoutVersion) return;
+
+					const newNodeSet = new Set(newNodeIds);
+					const mergedNodes = layoutedNodes.map((ln) => {
+						if (newNodeSet.has(ln.id)) return ln; // new node gets ELK position
+						const existing = existingPositions.get(ln.id);
+						if (existing) return { ...ln, position: existing }; // keep existing
+						return ln;
+					});
+
+					flowNodesStore.set(mergedNodes);
+					flowEdgesStore.set(layoutedEdges);
+				} else if (newNodeIds.length >= nodes.length * 0.5) {
+					// Major topology change (>50% new): full re-layout
+					const { nodes: layoutedNodes, edges: layoutedEdges } = await applyElkLayout(
+						flowNodes,
+						flowEdges,
+						{ algorithm: 'layered', nodeSpacing: 150 }
+					);
+
+					if (thisVersion !== layoutVersion) return;
+
+					flowNodesStore.set(layoutedNodes);
+					flowEdgesStore.set(layoutedEdges);
+				} else {
+					// No new nodes, just nodes were removed — update in place
+					if (thisVersion !== layoutVersion) return;
+
+					flowNodesStore.set(flowNodes);
+					flowEdgesStore.set(flowEdges);
+				}
+			}
 		} catch (error) {
+			if (thisVersion !== layoutVersion) return;
 			console.error('Layout failed:', error);
 			// Fallback: just set nodes with grid positions
 			const cols = Math.ceil(Math.sqrt(nodes.length));
@@ -328,8 +420,11 @@
 
 			flowNodesStore.set(flowNodes);
 			flowEdgesStore.set(flowEdges);
+			if (!hasInitialLayout) hasInitialLayout = true;
 		} finally {
-			isLayouting = false;
+			if (thisVersion === layoutVersion) {
+				isLayouting = false;
+			}
 		}
 	}
 
@@ -369,7 +464,7 @@
 		if (fitViewRef) fitViewRef({ duration: 400, padding: 0.1 });
 	}
 
-	// Capture flow instance when mounted, defer fitView for smoother rendering
+	// Capture flow instance when mounted, only fitView on initial layout
 	function captureFlowInstance() {
 		const { fitBounds, fitView } = useSvelteFlow();
 		fitBoundsRef = fitBounds;
@@ -380,8 +475,8 @@
 	}
 </script>
 
-<div class="h-full w-full">
-	{#if isLayouting}
+<div class="h-full w-full relative">
+	{#if isLayouting && !hasInitialLayout}
 		<div class="flex h-full items-center justify-center">
 			<div class="text-muted-foreground">Calculating layout...</div>
 		</div>
@@ -416,5 +511,12 @@
 				/>
 			</SvelteFlow>
 		</SvelteFlowProvider>
+	{/if}
+
+	<!-- Layout update indicator (shown as overlay, does NOT unmount the graph) -->
+	{#if isLayouting && hasInitialLayout}
+		<div class="absolute top-2 left-1/2 -translate-x-1/2 z-10 rounded-md bg-card/90 border border-border px-3 py-1.5 text-xs text-muted-foreground shadow-sm">
+			Updating layout...
+		</div>
 	{/if}
 </div>

--- a/frontend/src/lib/components/graph/NetworkGraph.svelte
+++ b/frontend/src/lib/components/graph/NetworkGraph.svelte
@@ -306,23 +306,30 @@
 		const thisVersion = ++layoutVersion;
 
 		try {
-			// Capture existing positions so we can preserve them on subsequent refreshes
-			const existingPositions = new Map<string, { x: number; y: number }>();
+			// Capture existing node state so we can preserve positions and measured dimensions
+			const existingNodes = new Map<string, Node>();
 			get(flowNodesStore).forEach((n) => {
-				existingPositions.set(n.id, { x: n.position.x, y: n.position.y });
+				existingNodes.set(n.id, n);
 			});
 			const isInitial = !hasInitialLayout;
 
-			// Convert to Svelte Flow format
-			const flowNodes: Node[] = nodes.map((node) => ({
-				id: node.id,
-				type: 'network',
-				position: existingPositions.get(node.id) ?? { x: 0, y: 0 },
-				data: {
-					label: node.displayName,
-					...node
-				}
-			}));
+			// Convert to Svelte Flow format, preserving measured dimensions from existing nodes
+			const flowNodes: Node[] = nodes.map((node) => {
+				const existing = existingNodes.get(node.id);
+				return {
+					id: node.id,
+					type: 'network',
+					position: existing?.position ?? { x: 0, y: 0 },
+					// Preserve measured dimensions so MiniMap continues to render nodes
+					...(existing?.measured ? { measured: existing.measured } : {}),
+					...(existing?.width != null ? { width: existing.width } : {}),
+					...(existing?.height != null ? { height: existing.height } : {}),
+					data: {
+						label: node.displayName,
+						...node
+					}
+				};
+			});
 
 			const flowEdges: Edge[] = edges.map((edge) => ({
 				id: edge.id,
@@ -348,7 +355,7 @@
 			} else {
 				// Subsequent refresh: preserve existing node positions, place new nodes
 				const newNodeIds = nodes
-					.filter((n) => !existingPositions.has(n.id))
+					.filter((n) => !existingNodes.has(n.id))
 					.map((n) => n.id);
 
 				if (newNodeIds.length > 0 && newNodeIds.length < nodes.length * 0.5) {
@@ -365,8 +372,16 @@
 					const newNodeSet = new Set(newNodeIds);
 					const mergedNodes = layoutedNodes.map((ln) => {
 						if (newNodeSet.has(ln.id)) return ln; // new node gets ELK position
-						const existing = existingPositions.get(ln.id);
-						if (existing) return { ...ln, position: existing }; // keep existing
+						const existing = existingNodes.get(ln.id);
+						if (existing) {
+							return {
+								...ln,
+								position: existing.position,
+								...(existing.measured ? { measured: existing.measured } : {}),
+								...(existing.width != null ? { width: existing.width } : {}),
+								...(existing.height != null ? { height: existing.height } : {})
+							};
+						}
 						return ln;
 					});
 
@@ -397,18 +412,24 @@
 			console.error('Layout failed:', error);
 			// Fallback: just set nodes with grid positions
 			const cols = Math.ceil(Math.sqrt(nodes.length));
-			const flowNodes: Node[] = nodes.map((node, index) => ({
-				id: node.id,
-				type: 'network',
-				position: {
-					x: (index % cols) * 300 + 50,
-					y: Math.floor(index / cols) * 180 + 50
-				},
-				data: {
-					label: node.displayName,
-					...node
-				}
-			}));
+			const flowNodes: Node[] = nodes.map((node, index) => {
+				const existing = get(flowNodesStore).find((n) => n.id === node.id);
+				return {
+					id: node.id,
+					type: 'network',
+					position: {
+						x: (index % cols) * 300 + 50,
+						y: Math.floor(index / cols) * 180 + 50
+					},
+					...(existing?.measured ? { measured: existing.measured } : {}),
+					...(existing?.width != null ? { width: existing.width } : {}),
+					...(existing?.height != null ? { height: existing.height } : {}),
+					data: {
+						label: node.displayName,
+						...node
+					}
+				};
+			});
 
 			const flowEdges: Edge[] = edges.map((edge) => ({
 				id: edge.id,

--- a/frontend/src/lib/components/layout/Header.svelte
+++ b/frontend/src/lib/components/layout/Header.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { RefreshCw, PanelLeft, ScrollText, Sun, Moon, Monitor, Network, Link, Activity, BarChart3, Shield } from 'lucide-svelte';
+	import { RefreshCw, PanelLeft, ScrollText, Sun, Moon, Monitor, Network, Link, Activity, BarChart3, Shield, Pause, Play } from 'lucide-svelte';
 	import { page } from '$app/stores';
-	import { uiStore, loadNetworkData, networkStats, filteredNodes, lastUpdated, isAutoRefreshing, themeStore, statsSummary, topTalkers } from '$lib/stores';
+	import { uiStore, loadNetworkData, networkStats, filteredNodes, lastUpdated, isAutoRefreshing, toggleAutoRefresh, themeStore, statsSummary, topTalkers } from '$lib/stores';
 	import { policyGraph } from '$lib/stores/policy-store';
 	import { formatBytes } from '$lib/utils';
 	import type { ThemeMode } from '$lib/stores';
@@ -200,17 +200,23 @@
 	<!-- Right section: Actions -->
 	<div class="flex items-center gap-1 sm:gap-2">
 		<button
+			onclick={() => toggleAutoRefresh()}
+			class="relative flex items-center gap-2 rounded-md p-2.5 hover:bg-secondary sm:px-3 sm:py-1.5"
+			title={$isAutoRefreshing ? 'Pause auto-refresh (P)' : 'Resume auto-refresh (P)'}
+		>
+			{#if $isAutoRefreshing}
+				<Pause class="h-4 w-4" />
+			{:else}
+				<Play class="h-4 w-4" />
+			{/if}
+		</button>
+
+		<button
 			onclick={handleRefresh}
 			class="relative flex items-center gap-2 rounded-md p-2.5 hover:bg-secondary sm:px-3 sm:py-1.5"
 			disabled={isRefreshing}
-			title={$isAutoRefreshing ? 'Auto-refreshing every 60s (R to manual refresh)' : 'Refresh (R)'}
+			title="Refresh now (R)"
 		>
-			{#if $isAutoRefreshing}
-				<span class="absolute -right-0.5 -top-0.5 flex h-2.5 w-2.5">
-					<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary/60"></span>
-					<span class="relative inline-flex h-2.5 w-2.5 rounded-full bg-primary"></span>
-				</span>
-			{/if}
 			<RefreshCw class="h-4 w-4 {isRefreshing ? 'animate-spin' : ''}" />
 			<span class="hidden text-sm sm:inline">Refresh</span>
 		</button>

--- a/frontend/src/lib/components/timeline/TimelineSlider.svelte
+++ b/frontend/src/lib/components/timeline/TimelineSlider.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Clock, Database, Radio } from 'lucide-svelte';
 	import { dataSourceStore, hasHistoricalData } from '$lib/stores/data-source-store';
-	import { loadNetworkData, startAutoRefresh, stopAutoRefresh } from '$lib/stores';
+	import { loadNetworkData, startAutoRefresh, stopAutoRefresh, AUTO_REFRESH_INTERVAL } from '$lib/stores';
 	import { onMount } from 'svelte';
 
 	// Debounce timer for reloading data
@@ -151,7 +151,7 @@
 			}
 		} else {
 			// Restart auto-refresh when switching back to live mode
-			startAutoRefresh(60_000);
+			startAutoRefresh(AUTO_REFRESH_INTERVAL);
 		}
 		// Single load - cancel any pending debounced reload
 		if (reloadTimeout) {

--- a/frontend/src/lib/stores/index.ts
+++ b/frontend/src/lib/stores/index.ts
@@ -26,7 +26,9 @@ export {
 	retryCount,
 	retryingIn,
 	startAutoRefresh,
-	stopAutoRefresh
+	stopAutoRefresh,
+	toggleAutoRefresh,
+	AUTO_REFRESH_INTERVAL
 } from './network-store';
 export { policyGraph, filteredGraph, parseSummary, fetchError, renderPolicy, runQuery, clearQuery, fetchAndRenderPolicy } from './policy-store';
 export {

--- a/frontend/src/lib/stores/network-store.ts
+++ b/frontend/src/lib/stores/network-store.ts
@@ -416,6 +416,9 @@ function convertAggregatedFlowsToNetworkLogs(flows: AggregatedFlow[], rangeStart
 	return Array.from(logsByNode.values());
 }
 
+// Centralized auto-refresh interval (5 minutes)
+export const AUTO_REFRESH_INTERVAL = 300_000;
+
 // Auto-refresh state
 export const isAutoRefreshing = writable(false);
 
@@ -430,7 +433,7 @@ if (typeof window !== 'undefined') {
 	});
 }
 
-export function startAutoRefresh(intervalMs = 300000) {
+export function startAutoRefresh(intervalMs = AUTO_REFRESH_INTERVAL) {
 	stopAutoRefresh();
 	// Don't auto-refresh in historical mode - data is static
 	const ds = get(dataSourceStore);
@@ -445,4 +448,12 @@ export function stopAutoRefresh() {
 		refreshInterval = null;
 	}
 	isAutoRefreshing.set(false);
+}
+
+export function toggleAutoRefresh() {
+	if (get(isAutoRefreshing)) {
+		stopAutoRefresh();
+	} else {
+		startAutoRefresh();
+	}
 }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -8,12 +8,12 @@
 	import BandwidthChart from '$lib/components/charts/BandwidthChart.svelte';
 	import EdgePolicyInfo from '$lib/components/logs/EdgePolicyInfo.svelte';
 	import Header from '$lib/components/layout/Header.svelte';
-	import { loadNetworkData, retryLoadNetworkData, retryCount, retryingIn, startAutoRefresh, stopAutoRefresh, filteredNodes, filteredEdges } from '$lib/stores/network-store';
+	import { loadNetworkData, retryLoadNetworkData, retryCount, retryingIn, startAutoRefresh, stopAutoRefresh, toggleAutoRefresh, filteredNodes, filteredEdges } from '$lib/stores/network-store';
 	import { uiStore } from '$lib/stores/ui-store';
 
 	onMount(() => {
 		loadNetworkData();
-		startAutoRefresh(60_000);
+		startAutoRefresh();
 	});
 
 	onDestroy(() => {
@@ -41,11 +41,14 @@
 			uiStore.toggleFilters();
 		} else if (e.key === 'l' && !e.metaKey && !e.ctrlKey) {
 			uiStore.toggleLogViewer();
+		} else if (e.key === 'p' && !e.metaKey && !e.ctrlKey) {
+			toggleAutoRefresh();
 		}
 	}
 
 	const shortcuts = [
 		{ key: 'R', desc: 'Refresh data' },
+		{ key: 'P', desc: 'Pause/resume auto-refresh' },
 		{ key: 'F', desc: 'Toggle filters' },
 		{ key: 'L', desc: 'Toggle log viewer' },
 		{ key: 'Esc', desc: 'Clear selection' },


### PR DESCRIPTION
## Problem
 
 On larger tailnets (100+ nodes, 300+ flows), the hardcoded 60-second auto-refresh interval causes the network graph
 to reset too frequently. Each refresh triggers a full ELK re-layout which destroys and rebuilds the entire 
SvelteFlow component, resetting the user's viewport (zoom/pan position). This makes the graph essentially unusable 
for exploration on busy networks.
 
 ## Solution
 
 Two targeted changes:
 
 1. **Increase the default auto-refresh interval from 60s to 5 minutes** — gives users time to explore the graph 
between refreshes
 2. **Add a pause/play toggle** — lets users stop auto-refresh entirely while investigating

I experimented with preserving node dimensions between refreshes, but it led to some unintended behavior and overlaps. I'll revisit this later.
 
 ### Changes (5 files, +37/-15 lines)
 
 | File | Change |
 |------|--------|
 | `network-store.ts` | Add `AUTO_REFRESH_INTERVAL` constant (300s), `toggleAutoRefresh()` function |
 | `stores/index.ts` | Export new symbols |
 | `+page.svelte` | Use centralized interval, add `P` keyboard shortcut |
 | `Header.svelte` | Add Pause/Play button (replaces ping indicator on refresh button) |
 | `TimelineSlider.svelte` | Use `AUTO_REFRESH_INTERVAL` instead of hardcoded `60_000` |
 
 ### UI
 
 - ⏸ **Pause** button in header when auto-refresh is active
 - ▶ **Play** button when paused
 - **P** keyboard shortcut toggles pause/play
 - **R** / Refresh button still triggers immediate manual refresh regardless of pause state
 - Auto-refresh still pauses in historical mode and resumes on switch to live
 
 ### No breaking changes
 
 - The interval is a single constant — easy to adjust
 - All existing functionality (manual refresh, historical mode, timeline slider) unchanged
 - NetworkGraph component is completely untouched
