### PR TITLE
fix(k8s): bump deployment image to v1.6.1 and sync on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  K8S_MANIFEST: k8s/deployment.yaml
 
 jobs:
   binaries:
@@ -80,3 +81,25 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
+
+  sync-k8s-image:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync k8s deployment image tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          sed -i "s#image: ghcr.io/rajsinghtech/tsflow:.*#image: ghcr.io/rajsinghtech/tsflow:${TAG}#" "${K8S_MANIFEST}"
+          if ! git diff --quiet -- "${K8S_MANIFEST}"; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add "${K8S_MANIFEST}"
+            git commit -m "chore(k8s): pin deployment image to ${TAG}"
+            git push origin main
+          fi

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: tsflow
-          image: ghcr.io/rajsinghtech/tsflow:v1.1.5
+          image: ghcr.io/rajsinghtech/tsflow:v1.6.1
           imagePullPolicy: Always
           ports:
             - name: http


### PR DESCRIPTION
Fixes #298

The `k8s/deployment.yaml` manifest was pinned to `v1.1.5` while the latest release is `v1.6.1`, so anyone deploying from the manifests thought they were getting a current version when they were actually pulling an image several releases behind.

## Changes

1. **Bump the image tag** in `k8s/deployment.yaml` from `v1.1.5` → `v1.6.1` (current latest release).
2. **Add sync to the release process** — a new `sync-k8s-image` job in `.github/workflows/release.yml` that runs after the `docker` job on every `v*.*.*` tag. It re-pins the manifest image tag to the released tag and commits it back to `main` if it changed, so the deployment manifest can't silently drift behind releases again.

## Test plan

- `k8s/deployment.yaml` and `release.yml` both parse as valid YAML.
- The image tag now matches the latest release (`v1.6.1`).
- The sync job is a no-op when the manifest already matches the tag (no diff → no commit), avoiding churn on `main`.

Closes #298