### PR TITLE
fix(policy): make relation edge color theme-aware for light mode

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -34,6 +34,9 @@
 	--color-traffic-virtual: #3b82f6;
 	--color-traffic-subnet: #10b981;
 	--color-traffic-physical: #f59e0b;
+
+	/* Policy graph edge colors */
+	--color-edge-relation: #9ca3af;
 }
 
 :root.light {
@@ -67,6 +70,9 @@
 	--color-traffic-virtual: #2563eb;
 	--color-traffic-subnet: #059669;
 	--color-traffic-physical: #d97706;
+
+	/* Policy graph edge colors - darker for light mode contrast */
+	--color-edge-relation: #52525b;
 }
 
 html {

--- a/frontend/src/lib/components/logs/EdgePolicyInfo.svelte
+++ b/frontend/src/lib/components/logs/EdgePolicyInfo.svelte
@@ -68,7 +68,7 @@
 					<div class="flex items-center gap-2 rounded bg-secondary/50 px-2 py-1 text-xs">
 						<span
 							class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase"
-							style="color: {edgeTypeColor[match.edgeType] ?? '#9ca3af'}; background: color-mix(in srgb, {edgeTypeColor[match.edgeType] ?? '#9ca3af'} 15%, transparent)"
+							style="color: {edgeTypeColor[match.edgeType] ?? 'var(--color-edge-relation)'}; background: color-mix(in srgb, {edgeTypeColor[match.edgeType] ?? 'var(--color-edge-relation)'} 15%, transparent)"
 						>
 							{match.edgeType}
 						</span>

--- a/frontend/src/lib/components/policy/AccessQuery.svelte
+++ b/frontend/src/lib/components/policy/AccessQuery.svelte
@@ -149,7 +149,7 @@
 						<div class="flex items-start gap-1">
 							<span
 								class="mt-0.5 inline-block shrink-0 rounded px-1 py-0.5 text-[10px] font-semibold uppercase"
-								style="color: {edgeColor[gm.edgeType] ?? '#9ca3af'}; background: color-mix(in srgb, {edgeColor[gm.edgeType] ?? '#9ca3af'} 15%, transparent)"
+								style="color: {edgeColor[gm.edgeType] ?? 'var(--color-edge-relation)'}; background: color-mix(in srgb, {edgeColor[gm.edgeType] ?? 'var(--color-edge-relation)'} 15%, transparent)"
 							>{gm.edgeType}</span>
 							<span class="text-muted-foreground">{gm.fullLabel}</span>
 						</div>

--- a/frontend/src/lib/components/policy/PolicyFilters.svelte
+++ b/frontend/src/lib/components/policy/PolicyFilters.svelte
@@ -13,7 +13,7 @@
 		{ key: 'showGrantEdges', label: 'Grants', color: '#0d9488', countKey: 'grant' },
 		{ key: 'showAclEdges', label: 'ACLs', color: '#0284c7', countKey: 'acl' },
 		{ key: 'showSshEdges', label: 'SSH', color: '#b45309', countKey: 'ssh' },
-		{ key: 'showRelationEdges', label: 'Relations', color: '#9ca3af', countKey: 'relation' }
+		{ key: 'showRelationEdges', label: 'Relations', color: 'var(--color-edge-relation)', countKey: 'relation' }
 	];
 
 	const nodeTypes: { key: keyof NodeVisibilityOptions; label: string; type: string }[] = [

--- a/frontend/src/lib/utils/policy-layout.ts
+++ b/frontend/src/lib/utils/policy-layout.ts
@@ -30,10 +30,10 @@ export const EDGE_STYLES: Record<string, { color: string; strokeDasharray?: stri
 	grant: { color: '#0d9488', width: 2, opacity: 1 },
 	acl: { color: '#0284c7', strokeDasharray: '6', width: 2, opacity: 1 },
 	ssh: { color: '#b45309', strokeDasharray: '2 4', width: 2, opacity: 1 },
-	'member-of': { color: '#9ca3af', width: 1, opacity: 0.4 },
-	'owns-tag': { color: '#9ca3af', width: 1, opacity: 0.4 },
-	contains: { color: '#9ca3af', width: 1, opacity: 0.4 },
-	'resolves-to': { color: '#9ca3af', width: 1, opacity: 0.4 }
+	'member-of': { color: 'var(--color-edge-relation)', width: 1, opacity: 0.6 },
+	'owns-tag': { color: 'var(--color-edge-relation)', width: 1, opacity: 0.6 },
+	contains: { color: 'var(--color-edge-relation)', width: 1, opacity: 0.6 },
+	'resolves-to': { color: 'var(--color-edge-relation)', width: 1, opacity: 0.6 }
 };
 
 const FAST_RENDER_NODE_THRESHOLD = 1500;


### PR DESCRIPTION
Reported from the Kubernetes-manifests channel: in Policy view with light mode, the **relation** edges are hard to see.

## Root cause

Relation edges (`member-of`, `owns-tag`, `contains`, `resolves-to`) were hardcoded to light gray `#9ca3af` at **40% opacity** in `EDGE_STYLES` (`frontend/src/lib/utils/policy-layout.ts`). On a white background in light mode that renders nearly invisible.

## Fix

Follow the repo's existing light-mode contrast pattern (node + traffic colors already get darker values via `:root.light` overrides):

1. Added a `--color-edge-relation` CSS variable in `app.css` — `#9ca3af` in dark mode, darker `#52525b` in light mode.
2. Pointed all four relation edge styles at the variable and raised relation opacity `0.4 → 0.6`.
3. Applied the same variable to the relation color swatches/badges in `PolicyFilters.svelte`, `AccessQuery.svelte`, and `EdgePolicyInfo.svelte` so the legend/filter/query UI stays in sync and legible in both themes.

## Validation

- `npm run check` (svelte-kit sync + svelte-check) passes with **0 errors, 0 warnings**.