### PR TITLE
Audit robustness and add regression coverage

### DIFF
--- a/.github/scripts/runtime-smoke.sh
+++ b/.github/scripts/runtime-smoke.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+binary="${1:?usage: runtime-smoke.sh /path/to/tsflow}"
+if [[ ! -x "$binary" ]]; then
+    printf 'runtime smoke: binary is missing or not executable: %s\n' "$binary" >&2
+    exit 1
+fi
+
+runtime_tmpdir="$(mktemp -d)"
+runtime_pid=""
+
+cleanup() {
+    if [[ -n "$runtime_pid" ]] && kill -0 "$runtime_pid" 2>/dev/null; then
+        kill "$runtime_pid" 2>/dev/null || true
+        wait "$runtime_pid" 2>/dev/null || true
+    fi
+    rm -rf "$runtime_tmpdir"
+}
+trap cleanup EXIT
+
+runtime_port="18080"
+runtime_log="$runtime_tmpdir/tsflow.log"
+
+TAILSCALE_API_KEY=runtime-smoke-key \
+TAILSCALE_TAILNET=runtime-smoke \
+TAILSCALE_API_URL=http://127.0.0.1:9 \
+TSFLOW_DB_PATH="$runtime_tmpdir/tsflow.db" \
+TSFLOW_INITIAL_BACKFILL=1m \
+TSFLOW_POLL_INTERVAL=1h \
+TSFLOW_RETENTION=0 \
+ENVIRONMENT=production \
+PORT="$runtime_port" \
+"$binary" >"$runtime_log" 2>&1 &
+runtime_pid=$!
+
+health_body=""
+for _ in {1..60}; do
+    if ! kill -0 "$runtime_pid" 2>/dev/null; then
+        printf 'runtime smoke: server exited before becoming ready\n' >&2
+        cat "$runtime_log" >&2
+        exit 1
+    fi
+    if health_body="$(curl --fail --silent --show-error --compressed --max-time 2 "http://127.0.0.1:${runtime_port}/health" 2>/dev/null)" \
+        && grep -q '"status":"healthy"' <<<"$health_body"; then
+        break
+    fi
+    sleep 0.25
+done
+
+if ! grep -q '"status":"healthy"' <<<"$health_body"; then
+    printf 'runtime smoke: /health did not become healthy\n' >&2
+    cat "$runtime_log" >&2
+    exit 1
+fi
+
+api_health_body="$(curl --fail --silent --show-error --compressed "http://127.0.0.1:${runtime_port}/api/health")"
+grep -q '"service":"tsflow-backend"' <<<"$api_health_body"
+
+index_body="$(curl --fail --silent --show-error --compressed "http://127.0.0.1:${runtime_port}/")"
+grep -q 'TSFlow - Tailscale Network Visualizer' <<<"$index_body"
+
+spa_body="$(curl --fail --silent --show-error --compressed "http://127.0.0.1:${runtime_port}/analytics")"
+grep -q 'TSFlow - Tailscale Network Visualizer' <<<"$spa_body"
+
+printf 'runtime smoke: health endpoints and embedded SPA passed\n'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
         working-directory: ./frontend
         run: npm run check
 
+      - name: Frontend tests
+        working-directory: ./frontend
+        run: npm run test
+
   test-backend:
     runs-on: ubuntu-latest
     steps:
@@ -78,3 +82,6 @@ jobs:
 
       - name: Verify binary
         run: ./backend/tsflow --help
+
+      - name: Embedded runtime smoke test
+        run: bash .github/scripts/runtime-smoke.sh ./backend/tsflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
         working-directory: ./backend
         run: go test -tags exclude_frontend ./...
 
+      - name: Race test
+        working-directory: ./backend
+        run: go test -race -tags exclude_frontend ./...
+
       - name: Vet
         working-directory: ./backend
         run: go vet -tags exclude_frontend ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
         run: go build -ldflags="-w -s" -o tsflow .
 
       - name: Verify binary
-        run: ./backend/tsflow --help || true
+        run: ./backend/tsflow --help

--- a/README.md
+++ b/README.md
@@ -234,9 +234,15 @@ volumes:
 
 ```bash
 cd k8s
-# Edit kustomization.yaml with your credentials
-kubectl apply -k .
+# Requires envsubst (provided by gettext). Export the variables referenced by
+# secret.yaml, then expand the template before applying the rendered manifests.
+kubectl kustomize . | envsubst | kubectl apply -f -
 ```
+
+Alternatively, replace the `${...}` placeholders in `k8s/secret.yaml` with
+your credentials and run `kubectl apply -k k8s` directly. Do not apply the
+template unchanged: Kubernetes does not expand shell-style environment
+variables in manifests.
 
 ## Star History
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ TSFlow will be accessible at both `https://tsflow.<your-tailnet>.ts.net` and `ht
 
 TSFlow stores per-minute flow aggregates in SQLite with a rolling retention window (default 30 days). Charts over wider windows use query-time bucketing — no data loss from pre-aggregation. When `TSFLOW_FLOW_BACKEND=s3`, TSFlow imports immutable `network/YYYY/MM/DD/*.ndjson`, `*.ndjson.zst`, `*.ndjson.zstd`, `*.ndjson.gz`, or `*.ndjson.gzip` objects from S3-compatible storage and tracks ingested object keys so repeated polling does not double count traffic.
 
+Raw flow-log endpoints are deprecated because raw events are not retained: use `/api/flow-logs/aggregated` for historical traffic. The legacy `/api/flow-logs` and `/api/devices/:deviceId/flows` routes return `410 Gone` with the replacement endpoint.
+
 Mount a volume to persist data: `-v tsflow_data:/app/data`
 
 ## Development

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -2,12 +2,14 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Config holds the application configuration
@@ -42,6 +44,9 @@ type Config struct {
 	FlowObjectStorePathStyle  bool
 	FlowObjectStoreLookback   string
 	FlowObjectStoreMaxObjects int
+	PollInterval              string
+	InitialBackfill           string
+	Retention                 string
 }
 
 // Load loads configuration from environment variables
@@ -75,6 +80,9 @@ func Load() *Config {
 		FlowObjectStorePathStyle:   parseBool(getEnvWithDefault("TSFLOW_S3_PATH_STYLE", "true"), true),
 		FlowObjectStoreLookback:    getEnvWithDefault("TSFLOW_S3_LOOKBACK", "15m"),
 		FlowObjectStoreMaxObjects:  parsePositiveInt(getEnvWithDefault("TSFLOW_S3_MAX_OBJECTS_PER_POLL", "500")),
+		PollInterval:               getEnvWithDefault("TSFLOW_POLL_INTERVAL", "5m"),
+		InitialBackfill:            getEnvWithDefault("TSFLOW_INITIAL_BACKFILL", "6h"),
+		Retention:                  getEnvWithFallback("TSFLOW_RETENTION"),
 	}
 }
 
@@ -109,6 +117,21 @@ func (c *Config) Validate() error {
 	if effectiveBackend == "s3" && !hasObjectCredentials {
 		return errors.New("s3 flow backend requires TSFLOW_S3_BUCKET, TSFLOW_S3_ENDPOINT, TSFLOW_S3_ACCESS_KEY_ID, and TSFLOW_S3_SECRET_ACCESS_KEY")
 	}
+	if effectiveBackend == "s3" {
+		parsedEndpoint, err := url.Parse(c.FlowObjectStoreEndpoint)
+		if err != nil || parsedEndpoint.Scheme == "" || parsedEndpoint.Host == "" {
+			return errors.New("TSFLOW_S3_ENDPOINT must be a valid absolute URL")
+		}
+		if parsedEndpoint.Scheme != "http" && parsedEndpoint.Scheme != "https" {
+			return errors.New("TSFLOW_S3_ENDPOINT must use http or https")
+		}
+		if err := validateDuration("TSFLOW_S3_LOOKBACK", c.FlowObjectStoreLookback, false); err != nil {
+			return err
+		}
+		if c.FlowObjectStoreMaxObjects <= 0 {
+			return errors.New("TSFLOW_S3_MAX_OBJECTS_PER_POLL must be a positive integer")
+		}
+	}
 
 	if c.TailscaleAPIURL == "" {
 		return errors.New("TAILSCALE_API_URL must not be empty")
@@ -119,6 +142,17 @@ func (c *Config) Validate() error {
 	}
 	if parsedAPIURL.Scheme != "http" && parsedAPIURL.Scheme != "https" {
 		return errors.New("TAILSCALE_API_URL must use http or https")
+	}
+	if err := validateDuration("TSFLOW_POLL_INTERVAL", c.PollInterval, false); err != nil {
+		return err
+	}
+	if err := validateDuration("TSFLOW_INITIAL_BACKFILL", c.InitialBackfill, false); err != nil {
+		return err
+	}
+	if c.Retention != "" {
+		if err := validateDuration("TSFLOW_RETENTION", c.Retention, true); err != nil {
+			return err
+		}
 	}
 	port, err := strconv.Atoi(c.Port)
 	if err != nil || port < 1 || port > 65535 {
@@ -185,6 +219,17 @@ func parsePositiveInt(s string) int {
 		return 0
 	}
 	return n
+}
+
+func validateDuration(name, value string, allowZero bool) error {
+	d, err := time.ParseDuration(strings.TrimSpace(value))
+	if err != nil || (allowZero && d < 0) || (!allowZero && d <= 0) {
+		if allowZero {
+			return fmt.Errorf("%s must be a duration of zero or greater", name)
+		}
+		return fmt.Errorf("%s must be a positive duration", name)
+	}
+	return nil
 }
 
 // parseScopes parses a comma-separated string of OAuth scopes

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -3,8 +3,10 @@ package config
 import (
 	"errors"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -55,22 +57,22 @@ func Load() *Config {
 		Port:                       getEnvWithDefault("PORT", "8080"),
 		Environment:                getEnvWithDefault("ENVIRONMENT", "development"),
 		AllowedCORSOrigins:         parseCORSOrigins(getEnvWithFallback("ALLOWED_CORS_ORIGINS")),
-		TsnetServe:                 os.Getenv("TSFLOW_SERVE") == "true",
+		TsnetServe:                 parseBool(os.Getenv("TSFLOW_SERVE"), false),
 		TsnetHostname:              getEnvWithDefault("TSFLOW_HOSTNAME", "tsflow"),
 		TsnetTags:                  parseTags(os.Getenv("TSFLOW_TAGS")),
-		TsnetFunnel:                os.Getenv("TSFLOW_FUNNEL") == "true",
+		TsnetFunnel:                parseBool(os.Getenv("TSFLOW_FUNNEL"), false),
 		TsnetStateDir:              getEnvWithDefault("TSFLOW_STATE_DIR", filepath.Join(".", "data", "tsnet-state")),
 		TsnetClientID:              os.Getenv("TS_CLIENT_ID"),
 		TsnetIDToken:               os.Getenv("TS_ID_TOKEN"),
 		TsnetAudience:              os.Getenv("TS_AUDIENCE"),
-		FlowBackend:                strings.ToLower(getEnvWithDefault("TSFLOW_FLOW_BACKEND", "")),
+		FlowBackend:                strings.ToLower(strings.TrimSpace(getEnvWithDefault("TSFLOW_FLOW_BACKEND", ""))),
 		FlowObjectStoreBucket:      getEnvWithDefault("TSFLOW_S3_BUCKET", getEnvWithDefault("TAILSCALE_LOGS_S3_BUCKET", "tailscale-logs")),
 		FlowObjectStorePrefix:      getEnvWithDefault("TSFLOW_S3_PREFIX", getEnvWithDefault("TAILSCALE_LOGS_S3_PREFIX", "network/")),
 		FlowObjectStoreEndpoint:    firstEnv("TSFLOW_S3_ENDPOINT", "TAILSCALE_LOGS_S3_ENDPOINT", "AWS_ENDPOINT_URL", "endpoint"),
 		FlowObjectStoreRegion:      getEnvWithDefault("TSFLOW_S3_REGION", getEnvWithDefault("AWS_REGION", getEnvWithDefault("AWS_DEFAULT_REGION", firstEnv("region")))),
 		FlowObjectStoreAccessKey:   firstEnv("TSFLOW_S3_ACCESS_KEY_ID", "TAILSCALE_LOGS_S3_ACCESS_KEY", "AWS_ACCESS_KEY_ID"),
 		FlowObjectStoreSecretKey:   firstEnv("TSFLOW_S3_SECRET_ACCESS_KEY", "TAILSCALE_LOGS_S3_SECRET_KEY", "AWS_SECRET_ACCESS_KEY"),
-		FlowObjectStorePathStyle:   getEnvWithDefault("TSFLOW_S3_PATH_STYLE", "true") != "false",
+		FlowObjectStorePathStyle:   parseBool(getEnvWithDefault("TSFLOW_S3_PATH_STYLE", "true"), true),
 		FlowObjectStoreLookback:    getEnvWithDefault("TSFLOW_S3_LOOKBACK", "15m"),
 		FlowObjectStoreMaxObjects:  parsePositiveInt(getEnvWithDefault("TSFLOW_S3_MAX_OBJECTS_PER_POLL", "500")),
 	}
@@ -81,10 +83,46 @@ func (c *Config) Validate() error {
 	hasAPIKey := c.TailscaleAPIKey != ""
 	hasOAuth := c.TailscaleOAuthClientID != "" && c.TailscaleOAuthClientSecret != ""
 	hasWIF := c.TsnetClientID != ""
-	hasObjectFlow := c.FlowBackend == "s3" || (c.FlowObjectStoreEndpoint != "" && c.FlowObjectStoreAccessKey != "" && c.FlowObjectStoreSecretKey != "")
+	backend := strings.ToLower(strings.TrimSpace(c.FlowBackend))
+	if backend != "" && backend != "api" && backend != "s3" {
+		return errors.New("TSFLOW_FLOW_BACKEND must be either api or s3")
+	}
 
-	if !hasAPIKey && !hasOAuth && !hasObjectFlow {
-		return errors.New("either TAILSCALE_API_KEY, both TAILSCALE_OAUTH_CLIENT_ID and TAILSCALE_OAUTH_CLIENT_SECRET, or TSFLOW_FLOW_BACKEND=s3 with object-store credentials must be provided")
+	hasObjectCredentials := c.FlowObjectStoreBucket != "" &&
+		c.FlowObjectStoreEndpoint != "" &&
+		c.FlowObjectStoreAccessKey != "" &&
+		c.FlowObjectStoreSecretKey != ""
+	effectiveBackend := backend
+	if effectiveBackend == "" {
+		// Preserve the historical auto-detection behavior only when the
+		// backend was not explicitly selected.
+		if hasObjectCredentials {
+			effectiveBackend = "s3"
+		} else {
+			effectiveBackend = "api"
+		}
+	}
+
+	if effectiveBackend == "api" && !hasAPIKey && !hasOAuth {
+		return errors.New("api flow backend requires TAILSCALE_API_KEY or both TAILSCALE_OAUTH_CLIENT_ID and TAILSCALE_OAUTH_CLIENT_SECRET")
+	}
+	if effectiveBackend == "s3" && !hasObjectCredentials {
+		return errors.New("s3 flow backend requires TSFLOW_S3_BUCKET, TSFLOW_S3_ENDPOINT, TSFLOW_S3_ACCESS_KEY_ID, and TSFLOW_S3_SECRET_ACCESS_KEY")
+	}
+
+	if c.TailscaleAPIURL == "" {
+		return errors.New("TAILSCALE_API_URL must not be empty")
+	}
+	parsedAPIURL, err := url.Parse(c.TailscaleAPIURL)
+	if err != nil || parsedAPIURL.Scheme == "" || parsedAPIURL.Host == "" {
+		return errors.New("TAILSCALE_API_URL must be a valid absolute URL")
+	}
+	if parsedAPIURL.Scheme != "http" && parsedAPIURL.Scheme != "https" {
+		return errors.New("TAILSCALE_API_URL must use http or https")
+	}
+	port, err := strconv.Atoi(c.Port)
+	if err != nil || port < 1 || port > 65535 {
+		return errors.New("PORT must be a number between 1 and 65535")
 	}
 
 	if hasAPIKey && hasOAuth {
@@ -105,11 +143,6 @@ func (c *Config) Validate() error {
 			if len(c.TsnetTags) == 0 {
 				return errors.New("workload identity federation requires TSFLOW_TAGS to be set")
 			}
-		}
-	}
-	if c.FlowBackend == "s3" {
-		if c.FlowObjectStoreBucket == "" || c.FlowObjectStoreEndpoint == "" || c.FlowObjectStoreAccessKey == "" || c.FlowObjectStoreSecretKey == "" {
-			return errors.New("TSFLOW_FLOW_BACKEND=s3 requires TSFLOW_S3_BUCKET, TSFLOW_S3_ENDPOINT, TSFLOW_S3_ACCESS_KEY_ID, and TSFLOW_S3_SECRET_ACCESS_KEY")
 		}
 	}
 
@@ -147,12 +180,9 @@ func firstEnv(keys ...string) string {
 }
 
 func parsePositiveInt(s string) int {
-	var n int
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return 0
-		}
-		n = n*10 + int(c-'0')
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil || n <= 0 {
+		return 0
 	}
 	return n
 }
@@ -162,9 +192,14 @@ func parseScopes(scopesStr string) []string {
 	if scopesStr == "" {
 		return []string{"all:read"}
 	}
-	scopes := strings.Split(scopesStr, ",")
-	for i, scope := range scopes {
-		scopes[i] = strings.TrimSpace(scope)
+	var scopes []string
+	for _, scope := range strings.Split(scopesStr, ",") {
+		if scope = strings.TrimSpace(scope); scope != "" {
+			scopes = append(scopes, scope)
+		}
+	}
+	if len(scopes) == 0 {
+		return []string{"all:read"}
 	}
 	return scopes
 }
@@ -174,9 +209,11 @@ func parseTags(tagsStr string) []string {
 	if tagsStr == "" {
 		return nil
 	}
-	tags := strings.Split(tagsStr, ",")
-	for i, tag := range tags {
-		tags[i] = strings.TrimSpace(tag)
+	var tags []string
+	for _, tag := range strings.Split(tagsStr, ",") {
+		if tag = strings.TrimSpace(tag); tag != "" {
+			tags = append(tags, tag)
+		}
 	}
 	return tags
 }
@@ -187,9 +224,26 @@ func parseCORSOrigins(originsStr string) []string {
 	if originsStr == "" {
 		return nil // Allow all origins when not specified
 	}
-	origins := strings.Split(originsStr, ",")
-	for i, origin := range origins {
-		origins[i] = strings.TrimSpace(origin)
+	var origins []string
+	for _, origin := range strings.Split(originsStr, ",") {
+		if origin = strings.TrimSpace(origin); origin != "" {
+			origins = append(origins, origin)
+		}
 	}
 	return origins
+}
+
+func parseBool(value string, defaultValue bool) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return defaultValue
+	}
+	switch strings.ToLower(value) {
+	case "true", "1", "t":
+		return true
+	case "false", "0", "f":
+		return false
+	default:
+		return defaultValue
+	}
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -6,7 +6,12 @@ import (
 )
 
 func validConfig() *Config {
-	return &Config{TailscaleAPIURL: "https://api.tailscale.com", Port: "8080"}
+	return &Config{
+		TailscaleAPIURL: "https://api.tailscale.com",
+		Port:            "8080",
+		PollInterval:    "5m",
+		InitialBackfill: "6h",
+	}
 }
 
 func objectStoreConfig(c *Config) {
@@ -14,6 +19,8 @@ func objectStoreConfig(c *Config) {
 	c.FlowObjectStoreEndpoint = "http://object-store.test"
 	c.FlowObjectStoreAccessKey = "access"
 	c.FlowObjectStoreSecretKey = "secret"
+	c.FlowObjectStoreLookback = "15m"
+	c.FlowObjectStoreMaxObjects = 500
 }
 
 func TestValidateExplicitBackends(t *testing.T) {
@@ -75,6 +82,7 @@ func TestLoadParsesValidatedEnvironmentValues(t *testing.T) {
 		"TAILSCALE_API_KEY", "VITE_TAILSCALE_API_KEY", "TAILSCALE_API_URL", "VITE_TAILSCALE_API_URL",
 		"PORT", "VITE_PORT", "TSFLOW_SERVE", "TSFLOW_FUNNEL", "TSFLOW_S3_PATH_STYLE",
 		"TSFLOW_S3_MAX_OBJECTS_PER_POLL", "TAILSCALE_OAUTH_SCOPES", "TSFLOW_TAGS",
+		"TSFLOW_POLL_INTERVAL", "TSFLOW_INITIAL_BACKFILL", "TSFLOW_RETENTION", "TSFLOW_S3_LOOKBACK",
 		"TAILSCALE_OAUTH_CLIENT_ID", "TAILSCALE_OAUTH_CLIENT_SECRET",
 		"TSFLOW_FLOW_BACKEND", "VITE_TSFLOW_FLOW_BACKEND", "TSFLOW_S3_BUCKET", "TSFLOW_S3_PREFIX",
 		"TSFLOW_S3_ENDPOINT", "TSFLOW_S3_REGION", "TSFLOW_S3_ACCESS_KEY_ID", "TSFLOW_S3_SECRET_ACCESS_KEY",
@@ -114,6 +122,37 @@ func TestLoadParsesValidatedEnvironmentValues(t *testing.T) {
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("loaded config should validate: %v", err)
+	}
+}
+
+func TestValidateRejectsUnsafeDurationsAndObjectStoreValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+		want   string
+	}{
+		{name: "zero poll interval", mutate: func(c *Config) { c.PollInterval = "0s" }, want: "TSFLOW_POLL_INTERVAL"},
+		{name: "negative poll interval", mutate: func(c *Config) { c.PollInterval = "-1s" }, want: "TSFLOW_POLL_INTERVAL"},
+		{name: "negative backfill", mutate: func(c *Config) { c.InitialBackfill = "-1m" }, want: "TSFLOW_INITIAL_BACKFILL"},
+		{name: "zero backfill", mutate: func(c *Config) { c.InitialBackfill = "0s" }, want: "TSFLOW_INITIAL_BACKFILL"},
+		{name: "negative retention", mutate: func(c *Config) { c.Retention = "-1m" }, want: "TSFLOW_RETENTION"},
+		{name: "invalid S3 lookback", mutate: func(c *Config) { objectStoreConfig(c); c.FlowBackend = "s3"; c.FlowObjectStoreLookback = "nope" }, want: "TSFLOW_S3_LOOKBACK"},
+		{name: "zero S3 object cap", mutate: func(c *Config) { objectStoreConfig(c); c.FlowBackend = "s3"; c.FlowObjectStoreMaxObjects = 0 }, want: "TSFLOW_S3_MAX_OBJECTS_PER_POLL"},
+		{name: "invalid S3 endpoint", mutate: func(c *Config) {
+			objectStoreConfig(c)
+			c.FlowBackend = "s3"
+			c.FlowObjectStoreEndpoint = "object-store.test"
+		}, want: "TSFLOW_S3_ENDPOINT"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.TailscaleAPIKey = "test-key"
+			tc.mutate(cfg)
+			if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate() error = %v, want mention %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func validConfig() *Config {
+	return &Config{TailscaleAPIURL: "https://api.tailscale.com", Port: "8080"}
+}
+
+func objectStoreConfig(c *Config) {
+	c.FlowObjectStoreBucket = "flows"
+	c.FlowObjectStoreEndpoint = "http://object-store.test"
+	c.FlowObjectStoreAccessKey = "access"
+	c.FlowObjectStoreSecretKey = "secret"
+}
+
+func TestValidateExplicitBackends(t *testing.T) {
+	t.Run("api requires API credentials", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.FlowBackend = "api"
+		objectStoreConfig(cfg)
+		if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "api flow backend") {
+			t.Fatalf("expected API credential error, got %v", err)
+		}
+	})
+
+	t.Run("s3 requires object store credentials", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.FlowBackend = "s3"
+		cfg.TailscaleAPIKey = "api-key"
+		if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "s3 flow backend") {
+			t.Fatalf("expected object-store credential error, got %v", err)
+		}
+	})
+
+	t.Run("valid explicit backends", func(t *testing.T) {
+		apiCfg := validConfig()
+		apiCfg.FlowBackend = "api"
+		apiCfg.TailscaleAPIKey = "api-key"
+		if err := apiCfg.Validate(); err != nil {
+			t.Fatalf("API backend should validate: %v", err)
+		}
+
+		s3Cfg := validConfig()
+		s3Cfg.FlowBackend = "s3"
+		objectStoreConfig(s3Cfg)
+		if err := s3Cfg.Validate(); err != nil {
+			t.Fatalf("S3 backend should validate: %v", err)
+		}
+	})
+}
+
+func TestValidateUnspecifiedBackendAutoDetection(t *testing.T) {
+	t.Run("object store credentials select S3", func(t *testing.T) {
+		cfg := validConfig()
+		objectStoreConfig(cfg)
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("expected S3 auto-detection: %v", err)
+		}
+	})
+
+	t.Run("API credentials select API", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.TailscaleAPIKey = "api-key"
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("expected API auto-detection: %v", err)
+		}
+	})
+}
+
+func TestLoadParsesValidatedEnvironmentValues(t *testing.T) {
+	for _, key := range []string{
+		"TAILSCALE_API_KEY", "VITE_TAILSCALE_API_KEY", "TAILSCALE_API_URL", "VITE_TAILSCALE_API_URL",
+		"PORT", "VITE_PORT", "TSFLOW_SERVE", "TSFLOW_FUNNEL", "TSFLOW_S3_PATH_STYLE",
+		"TSFLOW_S3_MAX_OBJECTS_PER_POLL", "TAILSCALE_OAUTH_SCOPES", "TSFLOW_TAGS",
+		"TAILSCALE_OAUTH_CLIENT_ID", "TAILSCALE_OAUTH_CLIENT_SECRET",
+		"TSFLOW_FLOW_BACKEND", "VITE_TSFLOW_FLOW_BACKEND", "TSFLOW_S3_BUCKET", "TSFLOW_S3_PREFIX",
+		"TSFLOW_S3_ENDPOINT", "TSFLOW_S3_REGION", "TSFLOW_S3_ACCESS_KEY_ID", "TSFLOW_S3_SECRET_ACCESS_KEY",
+		"TAILSCALE_LOGS_S3_BUCKET", "TAILSCALE_LOGS_S3_PREFIX", "TAILSCALE_LOGS_S3_ENDPOINT",
+		"TAILSCALE_LOGS_S3_ACCESS_KEY", "TAILSCALE_LOGS_S3_SECRET_KEY", "AWS_ENDPOINT_URL", "AWS_REGION",
+		"AWS_DEFAULT_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+	} {
+		t.Setenv(key, "")
+	}
+	t.Setenv("TAILSCALE_API_KEY", "key")
+	t.Setenv("TSFLOW_FLOW_BACKEND", " api ")
+	t.Setenv("TAILSCALE_OAUTH_CLIENT_ID", "client-id")
+	t.Setenv("TAILSCALE_OAUTH_CLIENT_SECRET", "client-secret")
+	t.Setenv("PORT", "9090")
+	t.Setenv("TSFLOW_SERVE", "TrUe")
+	t.Setenv("TSFLOW_FUNNEL", "not-a-bool")
+	t.Setenv("TSFLOW_S3_PATH_STYLE", "false")
+	t.Setenv("TSFLOW_S3_MAX_OBJECTS_PER_POLL", "42")
+	t.Setenv("TAILSCALE_OAUTH_SCOPES", " all:read, , devices:read ")
+	t.Setenv("TSFLOW_TAGS", " tag:one, ,tag:two ")
+
+	cfg := Load()
+	if cfg.FlowBackend != "api" {
+		t.Fatalf("flow backend = %q, want api", cfg.FlowBackend)
+	}
+	if cfg.Port != "9090" || !cfg.TsnetServe || cfg.TsnetFunnel {
+		t.Fatalf("unexpected boolean/port parsing: %+v", cfg)
+	}
+	if cfg.FlowObjectStorePathStyle || cfg.FlowObjectStoreMaxObjects != 42 {
+		t.Fatalf("unexpected object-store parsing: %+v", cfg)
+	}
+	if got, want := strings.Join(cfg.TailscaleOAuthScopes, "|"), "all:read|devices:read"; got != want {
+		t.Fatalf("scopes = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(cfg.TsnetTags, "|"), "tag:one|tag:two"; got != want {
+		t.Fatalf("tags = %q, want %q", got, want)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("loaded config should validate: %v", err)
+	}
+}
+
+func TestValidateURLAndPort(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		url  string
+		port string
+	}{
+		{name: "missing scheme", url: "api.tailscale.com", port: "8080"},
+		{name: "unsupported scheme", url: "ftp://api.tailscale.com", port: "8080"},
+		{name: "bad port", url: "https://api.tailscale.com", port: "70000"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.TailscaleAPIKey = "key"
+			cfg.TailscaleAPIURL = tc.url
+			cfg.Port = tc.port
+			if err := cfg.Validate(); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}

--- a/backend/internal/database/aggregate_queries.go
+++ b/backend/internal/database/aggregate_queries.go
@@ -86,8 +86,13 @@ func (s *SQLiteStore) CommitPollResults(ctx context.Context, results PollResults
 
 	const sqliteFormat = "2006-01-02 15:04:05"
 	_, err = tx.ExecContext(ctx,
-		"UPDATE poll_state SET last_poll_end = ?, updated_at = CURRENT_TIMESTAMP WHERE id = 1",
-		results.PollEnd.UTC().Format(sqliteFormat),
+		`UPDATE poll_state
+		 SET last_poll_end = CASE
+		       WHEN last_poll_end IS NULL OR last_poll_end = '' OR datetime(last_poll_end) IS NULL OR datetime(last_poll_end) < datetime(?)
+		       THEN ? ELSE last_poll_end END,
+		     updated_at = CURRENT_TIMESTAMP
+		 WHERE id = 1`,
+		results.PollEnd.UTC().Format(sqliteFormat), results.PollEnd.UTC().Format(sqliteFormat),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update poll state: %w", err)
@@ -142,8 +147,13 @@ func (s *SQLiteStore) CommitObjectIngest(ctx context.Context, result ObjectInges
 	}
 
 	_, err = tx.ExecContext(ctx,
-		"UPDATE poll_state SET last_poll_end = ?, updated_at = CURRENT_TIMESTAMP WHERE id = 1",
-		result.PollEnd.UTC().Format(sqliteFormat),
+		`UPDATE poll_state
+		 SET last_poll_end = CASE
+		       WHEN last_poll_end IS NULL OR last_poll_end = '' OR datetime(last_poll_end) IS NULL OR datetime(last_poll_end) < datetime(?)
+		       THEN ? ELSE last_poll_end END,
+		     updated_at = CURRENT_TIMESTAMP
+		 WHERE id = 1`,
+		result.PollEnd.UTC().Format(sqliteFormat), result.PollEnd.UTC().Format(sqliteFormat),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update poll state: %w", err)
@@ -859,7 +869,8 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 			FROM node_pairs np, json_each(
 				CASE WHEN json_valid(np.protocols) THEN np.protocols ELSE '[]' END) AS j
 			WHERE np.bucket >= ? AND np.bucket < ? AND np.traffic_type != 'physical'%s
-			  AND (np.protocol_bytes IS NULL OR np.protocol_bytes = '' OR np.protocol_bytes = '{}')
+			  AND (np.protocol_bytes IS NULL OR np.protocol_bytes = '' OR np.protocol_bytes = '{}'
+			       OR NOT json_valid(np.protocol_bytes))
 			  AND json_array_length(CASE WHEN json_valid(np.protocols) THEN np.protocols ELSE '[]' END) > 0
 		)
 		SELECT b, proto, SUM(bytes)

--- a/backend/internal/database/aggregate_queries.go
+++ b/backend/internal/database/aggregate_queries.go
@@ -972,21 +972,47 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 	bs := resolveBucketSize(endUnix - startUnix)
 	typeClause, typeArgs := trafficTypeWhereClause(trafficTypes)
 	query := fmt.Sprintf(`
-		SELECT (bucket / %d) * %d AS b,
-		       SUM(CASE WHEN traffic_type = 'virtual'
-		                THEN tx_bytes + rx_bytes ELSE 0 END) AS virtual_bytes,
-		       SUM(CASE WHEN traffic_type = 'exit'
-		                THEN tx_bytes + rx_bytes ELSE 0 END) AS exit_bytes,
-		       SUM(CASE WHEN traffic_type = 'subnet'
-		                THEN tx_bytes + rx_bytes ELSE 0 END) AS subnet_bytes,
-		       SUM(CASE WHEN traffic_type = 'physical'
-		                THEN tx_bytes + rx_bytes ELSE 0 END) AS physical_bytes,
-		       SUM(flow_count) AS total_flows,
-		       COUNT(DISTINCT src_node_id || '|' || dst_node_id) AS unique_pairs
-		FROM node_pairs
-		WHERE bucket >= ? AND bucket < ?%s
-		GROUP BY b
-		ORDER BY b ASC
+		WITH filtered_pairs AS (
+			SELECT (bucket / %d) * %d AS b,
+			       src_node_id,
+			       dst_node_id,
+			       traffic_type,
+			       tx_bytes,
+			       rx_bytes,
+			       flow_count
+			FROM node_pairs
+			WHERE bucket >= ? AND bucket < ?%s
+		), traffic_totals AS (
+			SELECT b,
+			       SUM(CASE WHEN traffic_type = 'virtual'
+			                THEN tx_bytes + rx_bytes ELSE 0 END) AS virtual_bytes,
+			       SUM(CASE WHEN traffic_type = 'exit'
+			                THEN tx_bytes + rx_bytes ELSE 0 END) AS exit_bytes,
+			       SUM(CASE WHEN traffic_type = 'subnet'
+			                THEN tx_bytes + rx_bytes ELSE 0 END) AS subnet_bytes,
+			       SUM(CASE WHEN traffic_type = 'physical'
+			                THEN tx_bytes + rx_bytes ELSE 0 END) AS physical_bytes,
+			       SUM(flow_count) AS total_flows
+			FROM filtered_pairs
+			GROUP BY b
+		), unique_pair_counts AS (
+			SELECT b, COUNT(*) AS unique_pairs
+			FROM (
+				SELECT DISTINCT b, src_node_id, dst_node_id
+				FROM filtered_pairs
+			)
+			GROUP BY b
+		)
+		SELECT t.b,
+		       t.virtual_bytes,
+		       t.exit_bytes,
+		       t.subnet_bytes,
+		       t.physical_bytes,
+		       t.total_flows,
+		       p.unique_pairs
+		FROM traffic_totals t
+		JOIN unique_pair_counts p ON p.b = t.b
+		ORDER BY t.b ASC
 	`, bs, bs, typeClause)
 
 	args := append([]any{startUnix, endUnix}, typeArgs...)

--- a/backend/internal/database/aggregate_queries.go
+++ b/backend/internal/database/aggregate_queries.go
@@ -191,10 +191,53 @@ func upsertNodePairsTx(ctx context.Context, tx *sql.Tx, aggregates []NodePairAgg
 		return nil
 	}
 
-	stmt, err := tx.PrepareContext(ctx, `
+	// Directional metadata is kept as JSON for consistency with the existing
+	// protocol and port aggregates. Keep the merge expressions here, alongside
+	// the legacy metadata merge, so one upsert remains atomic.
+	mergeProtocolBytes := func(existing, incoming string) string {
+		return fmt.Sprintf(`(
+				SELECT COALESCE(json_group_object(proto, bytes), '{}')
+				FROM (
+					SELECT CAST(key AS INTEGER) AS proto,
+					       SUM(CAST(value AS INTEGER)) AS bytes
+					FROM (
+						SELECT key, value FROM json_each(
+							CASE WHEN json_valid(%s) THEN %s ELSE '{}' END)
+						UNION ALL
+						SELECT key, value FROM json_each(
+							CASE WHEN json_valid(%s) THEN %s ELSE '{}' END)
+					) AS directional_protocol_values
+					GROUP BY proto
+					ORDER BY proto
+				)
+			)`, existing, existing, incoming, incoming)
+	}
+	mergePorts := func(existing, incoming string) string {
+		return fmt.Sprintf(`(
+				SELECT COALESCE(json_group_array(json_object('port', port, 'proto', proto, 'bytes', bytes)), '[]')
+				FROM (
+					SELECT CAST(json_extract(value, '$.port') AS INTEGER) AS port,
+					       CAST(json_extract(value, '$.proto') AS INTEGER) AS proto,
+					       SUM(CAST(json_extract(value, '$.bytes') AS INTEGER)) AS bytes
+					FROM (
+						SELECT value FROM json_each(
+							CASE WHEN json_valid(%s) THEN %s ELSE '[]' END)
+						UNION ALL
+						SELECT value FROM json_each(
+							CASE WHEN json_valid(%s) THEN %s ELSE '[]' END)
+					) AS directional_port_values
+					GROUP BY proto, port
+					ORDER BY bytes DESC, proto ASC, port ASC
+					LIMIT 20
+				)
+			)`, existing, existing, incoming, incoming)
+	}
+
+	stmt, err := tx.PrepareContext(ctx, fmt.Sprintf(`
 		INSERT INTO node_pairs (bucket, src_node_id, dst_node_id, traffic_type,
-		                        tx_bytes, rx_bytes, tx_pkts, rx_pkts, flow_count, protocols, protocol_bytes, ports)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		                        tx_bytes, rx_bytes, tx_pkts, rx_pkts, flow_count, protocols, protocol_bytes, ports,
+		                        tx_ports, rx_ports, tx_protocol_bytes, rx_protocol_bytes, directional_ports)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(bucket, src_node_id, dst_node_id, traffic_type) DO UPDATE SET
 			tx_bytes   = tx_bytes   + excluded.tx_bytes,
 			rx_bytes   = rx_bytes   + excluded.rx_bytes,
@@ -250,8 +293,22 @@ func upsertNodePairsTx(ctx context.Context, tx *sql.Tx, aggregates []NodePairAgg
 					ORDER BY bytes DESC, proto ASC, port ASC
 					LIMIT 20
 				)
-			)
-	`)
+			),
+			tx_protocol_bytes = %s,
+			rx_protocol_bytes = %s,
+			tx_ports = %s,
+			rx_ports = %s,
+			directional_ports = CASE
+				WHEN COALESCE(node_pairs.directional_ports, 0) = 1
+				 AND COALESCE(excluded.directional_ports, 0) = 1 THEN 1
+				ELSE 0
+			END
+	`,
+		mergeProtocolBytes("node_pairs.tx_protocol_bytes", "excluded.tx_protocol_bytes"),
+		mergeProtocolBytes("node_pairs.rx_protocol_bytes", "excluded.rx_protocol_bytes"),
+		mergePorts("node_pairs.tx_ports", "excluded.tx_ports"),
+		mergePorts("node_pairs.rx_ports", "excluded.rx_ports"),
+	))
 	if err != nil {
 		return fmt.Errorf("failed to prepare node_pairs upsert: %w", err)
 	}
@@ -265,7 +322,10 @@ func upsertNodePairsTx(ctx context.Context, tx *sql.Tx, aggregates []NodePairAgg
 			agg.TxBytes, agg.RxBytes, agg.TxPkts, agg.RxPkts,
 			agg.FlowCount, agg.Protocols,
 			normalizeProtocolBytes(agg.ProtocolBytes, agg.Protocols, agg.TxBytes+agg.RxBytes),
-			agg.Ports,
+			agg.Ports, agg.TxPorts, agg.RxPorts,
+			normalizeProtocolBytes(agg.TxProtocolBytes, "[]", agg.TxBytes),
+			normalizeProtocolBytes(agg.RxProtocolBytes, "[]", agg.RxBytes),
+			agg.DirectionalPorts,
 		); err != nil {
 			return fmt.Errorf("failed to upsert node pair: %w", err)
 		}
@@ -459,7 +519,64 @@ func (s *SQLiteStore) GetNodePairAggregates(ctx context.Context, start, end time
 		                    GROUP BY proto, port
 		                    ORDER BY bytes DESC, proto ASC, port ASC
 		                    LIMIT 20
-		                 )), '[]')
+		                 )), '[]'),
+		       COALESCE((SELECT json_group_object(proto, bytes) FROM (
+		                    SELECT CAST(j.key AS INTEGER) AS proto,
+		                           SUM(CAST(j.value AS INTEGER)) AS bytes
+		                    FROM node_pairs sub, json_each(
+		                        CASE WHEN json_valid(sub.tx_protocol_bytes)
+		                             THEN sub.tx_protocol_bytes ELSE '{}' END) AS j
+		                    WHERE sub.src_node_id = main.src_node_id
+		                      AND sub.dst_node_id = main.dst_node_id
+		                      AND sub.traffic_type = main.traffic_type
+		                      AND sub.bucket >= ? AND sub.bucket < ?
+		                    GROUP BY proto
+		                    ORDER BY proto ASC
+		                 )), '{}'),
+		       COALESCE((SELECT json_group_object(proto, bytes) FROM (
+		                    SELECT CAST(j.key AS INTEGER) AS proto,
+		                           SUM(CAST(j.value AS INTEGER)) AS bytes
+		                    FROM node_pairs sub, json_each(
+		                        CASE WHEN json_valid(sub.rx_protocol_bytes)
+		                             THEN sub.rx_protocol_bytes ELSE '{}' END) AS j
+		                    WHERE sub.src_node_id = main.src_node_id
+		                      AND sub.dst_node_id = main.dst_node_id
+		                      AND sub.traffic_type = main.traffic_type
+		                      AND sub.bucket >= ? AND sub.bucket < ?
+		                    GROUP BY proto
+		                    ORDER BY proto ASC
+		                 )), '{}'),
+		       COALESCE((SELECT json_group_array(json_object('port', port, 'proto', proto, 'bytes', bytes)) FROM (
+		                    SELECT CAST(json_extract(j.value, '$.port') AS INTEGER) AS port,
+		                           CAST(json_extract(j.value, '$.proto') AS INTEGER) AS proto,
+		                           SUM(CAST(json_extract(j.value, '$.bytes') AS INTEGER)) AS bytes
+		                    FROM node_pairs sub, json_each(
+		                        CASE WHEN json_valid(sub.tx_ports)
+		                             THEN sub.tx_ports ELSE '[]' END) AS j
+		                    WHERE sub.src_node_id = main.src_node_id
+		                      AND sub.dst_node_id = main.dst_node_id
+		                      AND sub.traffic_type = main.traffic_type
+		                      AND sub.bucket >= ? AND sub.bucket < ?
+		                    GROUP BY proto, port
+		                    ORDER BY bytes DESC, proto ASC, port ASC
+		                    LIMIT 20
+		                 )), '[]'),
+		       COALESCE((SELECT json_group_array(json_object('port', port, 'proto', proto, 'bytes', bytes)) FROM (
+		                    SELECT CAST(json_extract(j.value, '$.port') AS INTEGER) AS port,
+		                           CAST(json_extract(j.value, '$.proto') AS INTEGER) AS proto,
+		                           SUM(CAST(json_extract(j.value, '$.bytes') AS INTEGER)) AS bytes
+		                    FROM node_pairs sub, json_each(
+		                        CASE WHEN json_valid(sub.rx_ports)
+		                             THEN sub.rx_ports ELSE '[]' END) AS j
+		                    WHERE sub.src_node_id = main.src_node_id
+		                      AND sub.dst_node_id = main.dst_node_id
+		                      AND sub.traffic_type = main.traffic_type
+		                      AND sub.bucket >= ? AND sub.bucket < ?
+		                    GROUP BY proto, port
+		                    ORDER BY bytes DESC, proto ASC, port ASC
+		                    LIMIT 20
+		                 )), '[]'),
+		       MIN(COALESCE(directional_ports, 0))
 		FROM node_pairs main
 		WHERE bucket >= ? AND bucket < ?
 		GROUP BY src_node_id, dst_node_id, traffic_type
@@ -467,6 +584,10 @@ func (s *SQLiteStore) GetNodePairAggregates(ctx context.Context, start, end time
 		         src_node_id ASC, dst_node_id ASC, traffic_type ASC
 	`
 	rows, err := s.db.QueryContext(ctx, query,
+		startUnix, endUnix,
+		startUnix, endUnix,
+		startUnix, endUnix,
+		startUnix, endUnix,
 		startUnix, endUnix,
 		startUnix, endUnix,
 		startUnix, endUnix,
@@ -484,6 +605,8 @@ func (s *SQLiteStore) GetNodePairAggregates(ctx context.Context, start, end time
 			&agg.Bucket, &agg.SrcNodeID, &agg.DstNodeID, &agg.TrafficType,
 			&agg.TxBytes, &agg.RxBytes, &agg.TxPkts, &agg.RxPkts,
 			&agg.FlowCount, &agg.Protocols, &agg.ProtocolBytes, &agg.Ports,
+			&agg.TxProtocolBytes, &agg.RxProtocolBytes, &agg.TxPorts, &agg.RxPorts,
+			&agg.DirectionalPorts,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan node pair: %w", err)
 		}

--- a/backend/internal/database/aggregate_queries.go
+++ b/backend/internal/database/aggregate_queries.go
@@ -428,7 +428,8 @@ func (s *SQLiteStore) GetNodePairAggregates(ctx context.Context, start, end time
 		FROM node_pairs main
 		WHERE bucket >= ? AND bucket < ?
 		GROUP BY src_node_id, dst_node_id, traffic_type
-		ORDER BY SUM(tx_bytes) + SUM(rx_bytes) DESC
+		ORDER BY SUM(tx_bytes) + SUM(rx_bytes) DESC,
+		         src_node_id ASC, dst_node_id ASC, traffic_type ASC
 	`
 	rows, err := s.db.QueryContext(ctx, query,
 		startUnix, endUnix,
@@ -653,17 +654,39 @@ func (s *SQLiteStore) GetTrafficStats(ctx context.Context, start, end time.Time)
 
 	bs := resolveBucketSize(endUnix - startUnix)
 	query := fmt.Sprintf(`
-		SELECT (bucket / %d) * %d AS b,
-		       SUM(tcp_bytes), SUM(udp_bytes), SUM(other_proto_bytes),
-		       SUM(virtual_bytes), SUM(subnet_bytes), SUM(physical_bytes),
-		       SUM(total_flows), MAX(unique_pairs)
-		FROM traffic_stats
-		WHERE bucket >= ? AND bucket < ?
-		GROUP BY b
-		ORDER BY b ASC
-	`, bs, bs)
+		WITH stat_buckets AS (
+			SELECT (bucket / %d) * %d AS b,
+			       SUM(tcp_bytes) AS tcp_bytes,
+			       SUM(udp_bytes) AS udp_bytes,
+			       SUM(other_proto_bytes) AS other_proto_bytes,
+			       SUM(virtual_bytes) AS virtual_bytes,
+			       SUM(subnet_bytes) AS subnet_bytes,
+			       SUM(physical_bytes) AS physical_bytes,
+			       SUM(total_flows) AS total_flows,
+			       MAX(unique_pairs) AS stored_unique_pairs
+			FROM traffic_stats
+			WHERE bucket >= ? AND bucket < ?
+			GROUP BY b
+		), pair_buckets AS (
+			SELECT b, COUNT(*) AS unique_pairs
+			FROM (
+				SELECT (bucket / %d) * %d AS b, src_node_id, dst_node_id
+				FROM node_pairs
+				WHERE bucket >= ? AND bucket < ?
+				GROUP BY b, src_node_id, dst_node_id
+			)
+			GROUP BY b
+		)
+		SELECT sb.b, sb.tcp_bytes, sb.udp_bytes, sb.other_proto_bytes,
+		       sb.virtual_bytes, sb.subnet_bytes, sb.physical_bytes,
+		       sb.total_flows,
+		       MAX(COALESCE(pb.unique_pairs, 0), COALESCE(sb.stored_unique_pairs, 0))
+		FROM stat_buckets sb
+		LEFT JOIN pair_buckets pb ON pb.b = sb.b
+		ORDER BY sb.b ASC
+	`, bs, bs, bs, bs)
 
-	rows, err := s.db.QueryContext(ctx, query, startUnix, endUnix)
+	rows, err := s.db.QueryContext(ctx, query, startUnix, endUnix, startUnix, endUnix)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query traffic stats: %w", err)
 	}
@@ -769,13 +792,18 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 	bs := resolveBucketSize(endUnix - startUnix)
 	typeClause, typeArgs := trafficTypeWhereClause(trafficTypes)
 	query := fmt.Sprintf(`
-		SELECT (bucket / %d) * %d AS b, traffic_type,
-		       SUM(tx_bytes + rx_bytes) AS total_bytes,
+		SELECT (bucket / %d) * %d AS b,
+		       SUM(CASE WHEN traffic_type IN ('virtual', 'exit')
+		                THEN tx_bytes + rx_bytes ELSE 0 END) AS virtual_bytes,
+		       SUM(CASE WHEN traffic_type = 'subnet'
+		                THEN tx_bytes + rx_bytes ELSE 0 END) AS subnet_bytes,
+		       SUM(CASE WHEN traffic_type = 'physical'
+		                THEN tx_bytes + rx_bytes ELSE 0 END) AS physical_bytes,
 		       SUM(flow_count) AS total_flows,
 		       COUNT(DISTINCT src_node_id || '|' || dst_node_id) AS unique_pairs
 		FROM node_pairs
 		WHERE bucket >= ? AND bucket < ?%s
-		GROUP BY b, traffic_type
+		GROUP BY b
 		ORDER BY b ASC
 	`, bs, bs, typeClause)
 
@@ -789,9 +817,8 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 	bucketMap := make(map[int64]*TrafficStats)
 	for rows.Next() {
 		var bucket int64
-		var trafficType string
-		var totalBytes, totalFlows, uniquePairs int64
-		if err := rows.Scan(&bucket, &trafficType, &totalBytes, &totalFlows, &uniquePairs); err != nil {
+		var virtualBytes, subnetBytes, physicalBytes, totalFlows, uniquePairs int64
+		if err := rows.Scan(&bucket, &virtualBytes, &subnetBytes, &physicalBytes, &totalFlows, &uniquePairs); err != nil {
 			return nil, fmt.Errorf("failed to scan: %w", err)
 		}
 		st, ok := bucketMap[bucket]
@@ -799,18 +826,11 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 			st = &TrafficStats{Bucket: bucket, TopPorts: "[]"}
 			bucketMap[bucket] = st
 		}
-		switch trafficType {
-		case "virtual", "exit":
-			st.VirtualBytes += totalBytes
-		case "subnet":
-			st.SubnetBytes += totalBytes
-		case "physical":
-			st.PhysicalBytes += totalBytes
-		}
+		st.VirtualBytes = virtualBytes
+		st.SubnetBytes = subnetBytes
+		st.PhysicalBytes = physicalBytes
 		st.TotalFlows += totalFlows
-		if uniquePairs > st.UniquePairs {
-			st.UniquePairs = uniquePairs
-		}
+		st.UniquePairs = uniquePairs
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -850,28 +870,36 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 	protoArgs = append(protoArgs, startUnix, endUnix)
 	protoArgs = append(protoArgs, typeArgs...)
 	protoRows, err := s.db.QueryContext(ctx, protoQuery, protoArgs...)
-	if err == nil {
-		for protoRows.Next() {
-			var b int64
-			var protocol int
-			var totalBytes int64
-			if err := protoRows.Scan(&b, &protocol, &totalBytes); err != nil {
-				continue
-			}
-			st, ok := bucketMap[b]
-			if !ok {
-				continue
-			}
-			switch protocol {
-			case 6:
-				st.TCPBytes += totalBytes
-			case 17:
-				st.UDPBytes += totalBytes
-			default:
-				st.OtherProtoBytes += totalBytes
-			}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query node pair protocols: %w", err)
+	}
+	for protoRows.Next() {
+		var b int64
+		var protocol int
+		var totalBytes int64
+		if err := protoRows.Scan(&b, &protocol, &totalBytes); err != nil {
+			protoRows.Close()
+			return nil, fmt.Errorf("failed to scan node pair protocol: %w", err)
 		}
+		st, ok := bucketMap[b]
+		if !ok {
+			continue
+		}
+		switch protocol {
+		case 6:
+			st.TCPBytes += totalBytes
+		case 17:
+			st.UDPBytes += totalBytes
+		default:
+			st.OtherProtoBytes += totalBytes
+		}
+	}
+	if err := protoRows.Err(); err != nil {
 		protoRows.Close()
+		return nil, fmt.Errorf("failed to read node pair protocols: %w", err)
+	}
+	if err := protoRows.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close node pair protocol rows: %w", err)
 	}
 
 	// Rebuild top ports for the same bucket size and traffic-type filter. The
@@ -900,22 +928,32 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 			ORDER BY b ASC, bytes DESC, proto ASC, port ASC
 	`, bs, bs, typeClause)
 	portRows, err := s.db.QueryContext(ctx, portQuery, args...)
-	if err == nil {
-		topPortsByBucket := make(map[int64][]PortStat)
-		for portRows.Next() {
-			var b int64
-			var port PortStat
-			if err := portRows.Scan(&b, &port.Proto, &port.Port, &port.Bytes); err != nil {
-				continue
-			}
-			topPortsByBucket[b] = append(topPortsByBucket[b], port)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query node pair ports: %w", err)
+	}
+	topPortsByBucket := make(map[int64][]PortStat)
+	for portRows.Next() {
+		var b int64
+		var port PortStat
+		if err := portRows.Scan(&b, &port.Proto, &port.Port, &port.Bytes); err != nil {
+			portRows.Close()
+			return nil, fmt.Errorf("failed to scan node pair port: %w", err)
 		}
+		topPortsByBucket[b] = append(topPortsByBucket[b], port)
+	}
+	if err := portRows.Err(); err != nil {
 		portRows.Close()
+		return nil, fmt.Errorf("failed to read node pair ports: %w", err)
+	}
+	if err := portRows.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close node pair port rows: %w", err)
+	}
 
-		for b, topPorts := range topPortsByBucket {
-			if encoded, err := json.Marshal(topPorts); err == nil {
-				bucketMap[b].TopPorts = string(encoded)
-			}
+	for b, topPorts := range topPortsByBucket {
+		if encoded, err := json.Marshal(topPorts); err != nil {
+			return nil, fmt.Errorf("failed to encode node pair ports: %w", err)
+		} else if st := bucketMap[b]; st != nil {
+			st.TopPorts = string(encoded)
 		}
 	}
 
@@ -1156,7 +1194,7 @@ func (s *SQLiteStore) GetNodeStats(ctx context.Context, nodeID string, start, en
 			GROUP BY src_node_id
 		)
 		GROUP BY peer_id
-		ORDER BY total DESC
+		ORDER BY total DESC, peer_id ASC
 		LIMIT 10
 	`, nodeID, startUnix, endUnix, nodeID, startUnix, endUnix)
 	if err != nil {

--- a/backend/internal/database/aggregate_queries.go
+++ b/backend/internal/database/aggregate_queries.go
@@ -1057,7 +1057,8 @@ func (s *SQLiteStore) GetTopTalkersByTrafficTypes(ctx context.Context, start, en
 			UNION ALL
 			SELECT dst_node_id AS node_id, SUM(rx_bytes) AS tx, SUM(tx_bytes) AS rx
 			FROM node_pairs
-			WHERE bucket >= ? AND bucket < ?%s
+			WHERE bucket >= ? AND bucket < ?
+			  AND src_node_id != dst_node_id%s
 			GROUP BY dst_node_id
 		)
 		SELECT node_id, SUM(tx) AS tx, SUM(rx) AS rx, SUM(tx + rx) AS total

--- a/backend/internal/database/aggregate_queries.go
+++ b/backend/internal/database/aggregate_queries.go
@@ -122,7 +122,10 @@ func (s *SQLiteStore) CommitObjectIngest(ctx context.Context, result ObjectInges
 	if err != nil {
 		return fmt.Errorf("failed to mark object as ingested: %w", err)
 	}
-	rows, _ := insertRes.RowsAffected()
+	rows, err := insertRes.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to determine whether object was newly ingested: %w", err)
+	}
 	if rows == 0 {
 		if err := upsertNodeMetadataTx(ctx, tx, result.NodeMetadata); err != nil {
 			return err
@@ -1218,6 +1221,7 @@ func (s *SQLiteStore) GetNodeStats(ctx context.Context, nodeID string, start, en
 			SELECT src_node_id AS peer_id, SUM(rx_bytes) AS tx, SUM(tx_bytes) AS rx, SUM(flow_count) AS fc
 			FROM node_pairs
 			WHERE dst_node_id = ? AND bucket >= ? AND bucket < ?
+			  AND src_node_id != dst_node_id
 			GROUP BY src_node_id
 		)
 		GROUP BY peer_id
@@ -1256,15 +1260,18 @@ func (s *SQLiteStore) GetNodeStats(ctx context.Context, nodeID string, start, en
 	for portRows.Next() {
 		var portsJSON string
 		if err := portRows.Scan(&portsJSON); err != nil {
-			continue
+			return nil, fmt.Errorf("failed to scan node ports: %w", err)
 		}
 		var entries []PortStat
 		if err := json.Unmarshal([]byte(portsJSON), &entries); err != nil {
-			continue
+			return nil, fmt.Errorf("failed to decode node ports: %w", err)
 		}
 		for _, e := range entries {
 			portAgg[protoPortKey{e.Proto, e.Port}] += e.Bytes
 		}
+	}
+	if err := portRows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read node ports: %w", err)
 	}
 	for ppk, bytes := range portAgg {
 		switch ppk.proto {

--- a/backend/internal/database/aggregate_queries.go
+++ b/backend/internal/database/aggregate_queries.go
@@ -127,10 +127,16 @@ func (s *SQLiteStore) CommitObjectIngest(ctx context.Context, result ObjectInges
 		if err := upsertNodeMetadataTx(ctx, tx, result.NodeMetadata); err != nil {
 			return err
 		}
+		if err := recordObjectMetadataTx(ctx, tx, result.Key, nodeMetadataIDs(result.NodeMetadata)); err != nil {
+			return err
+		}
 		return tx.Commit()
 	}
 
 	if err := upsertNodeMetadataTx(ctx, tx, result.NodeMetadata); err != nil {
+		return err
+	}
+	if err := recordObjectMetadataTx(ctx, tx, result.Key, nodeMetadataIDs(result.NodeMetadata)); err != nil {
 		return err
 	}
 	if err := upsertNodePairsTx(ctx, tx, result.NodePairs); err != nil {
@@ -160,6 +166,16 @@ func (s *SQLiteStore) CommitObjectIngest(ctx context.Context, result ObjectInges
 	}
 
 	return tx.Commit()
+}
+
+func nodeMetadataIDs(nodes []NodeMetadata) []string {
+	ids := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if node.NodeID != "" {
+			ids = append(ids, node.NodeID)
+		}
+	}
+	return ids
 }
 
 func upsertNodePairsTx(ctx context.Context, tx *sql.Tx, aggregates []NodePairAggregate) error {
@@ -380,7 +396,7 @@ func (s *SQLiteStore) UpsertNodePairAggregates(ctx context.Context, aggregates [
 }
 
 // GetNodePairAggregates retrieves node-pair aggregates for a time range.
-func (s *SQLiteStore) GetNodePairAggregates(ctx context.Context, start, end time.Time, bucketSize int64) ([]NodePairAggregate, error) {
+func (s *SQLiteStore) GetNodePairAggregates(ctx context.Context, start, end time.Time) ([]NodePairAggregate, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -857,7 +873,7 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 			FROM node_pairs np, json_each(
 				CASE WHEN json_valid(np.protocol_bytes) AND np.protocol_bytes != '{}'
 				     THEN np.protocol_bytes ELSE '{}' END) AS j
-			WHERE np.bucket >= ? AND np.bucket < ? AND np.traffic_type != 'physical'%s
+			WHERE np.bucket >= ? AND np.bucket < ?%s
 			UNION ALL
 			SELECT (np.bucket / %d) * %d AS b,
 			       CAST(j.value AS INTEGER) AS proto,
@@ -868,7 +884,7 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 				         ELSE 0 END AS bytes
 			FROM node_pairs np, json_each(
 				CASE WHEN json_valid(np.protocols) THEN np.protocols ELSE '[]' END) AS j
-			WHERE np.bucket >= ? AND np.bucket < ? AND np.traffic_type != 'physical'%s
+			WHERE np.bucket >= ? AND np.bucket < ?%s
 			  AND (np.protocol_bytes IS NULL OR np.protocol_bytes = '' OR np.protocol_bytes = '{}'
 			       OR NOT json_valid(np.protocol_bytes))
 			  AND json_array_length(CASE WHEN json_valid(np.protocols) THEN np.protocols ELSE '[]' END) > 0

--- a/backend/internal/database/aggregate_queries.go
+++ b/backend/internal/database/aggregate_queries.go
@@ -25,6 +25,41 @@ func resolveBucketSize(rangeSeconds int64) int64 {
 	return 86400
 }
 
+// normalizeProtocolBytes returns a usable protocol-to-byte map for an
+// aggregate. New callers provide exact byte totals; older callers only have
+// the set of protocols, so their bytes are divided deterministically across
+// that set as a compatibility fallback.
+func normalizeProtocolBytes(raw, protocolsJSON string, totalBytes int64) string {
+	var existing map[string]int64
+	if json.Unmarshal([]byte(raw), &existing) == nil && len(existing) > 0 {
+		encoded, err := json.Marshal(existing)
+		if err == nil {
+			return string(encoded)
+		}
+	}
+
+	var protocols []int
+	if json.Unmarshal([]byte(protocolsJSON), &protocols) != nil || len(protocols) == 0 {
+		return "{}"
+	}
+	sort.Ints(protocols)
+	perProtocol := totalBytes / int64(len(protocols))
+	remainder := totalBytes - perProtocol*int64(len(protocols))
+	derived := make(map[string]int64, len(protocols))
+	for i, protocol := range protocols {
+		bytes := perProtocol
+		if i == 0 {
+			bytes += remainder
+		}
+		derived[fmt.Sprint(protocol)] = bytes
+	}
+	encoded, err := json.Marshal(derived)
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}
+
 // CommitPollResults atomically writes all aggregates and updates poll state.
 func (s *SQLiteStore) CommitPollResults(ctx context.Context, results PollResults) error {
 	s.mu.Lock()
@@ -124,20 +159,64 @@ func upsertNodePairsTx(ctx context.Context, tx *sql.Tx, aggregates []NodePairAgg
 
 	stmt, err := tx.PrepareContext(ctx, `
 		INSERT INTO node_pairs (bucket, src_node_id, dst_node_id, traffic_type,
-		                        tx_bytes, rx_bytes, tx_pkts, rx_pkts, flow_count, protocols, ports)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		                        tx_bytes, rx_bytes, tx_pkts, rx_pkts, flow_count, protocols, protocol_bytes, ports)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(bucket, src_node_id, dst_node_id, traffic_type) DO UPDATE SET
 			tx_bytes   = tx_bytes   + excluded.tx_bytes,
 			rx_bytes   = rx_bytes   + excluded.rx_bytes,
 			tx_pkts    = tx_pkts    + excluded.tx_pkts,
 			rx_pkts    = rx_pkts    + excluded.rx_pkts,
 			flow_count = flow_count + excluded.flow_count,
-			protocols  = (SELECT json_group_array(value) FROM (
-			                 SELECT value FROM json_each(node_pairs.protocols)
-			                 UNION
-			                 SELECT value FROM json_each(excluded.protocols)
+			protocols  = (SELECT COALESCE(json_group_array(value), '[]') FROM (
+			                 SELECT value FROM (
+				                 SELECT value FROM json_each(
+					                 CASE WHEN json_valid(node_pairs.protocols)
+					                              THEN node_pairs.protocols ELSE '[]' END)
+				                 UNION
+				                 SELECT value FROM json_each(
+					                 CASE WHEN json_valid(excluded.protocols)
+					                              THEN excluded.protocols ELSE '[]' END)
+			                 ) AS protocol_values
+				                 ORDER BY CAST(value AS INTEGER)
 			              )),
-			ports = excluded.ports
+			protocol_bytes = (
+				SELECT COALESCE(json_group_object(proto, bytes), '{}')
+				FROM (
+					SELECT CAST(key AS INTEGER) AS proto,
+					       SUM(CAST(value AS INTEGER)) AS bytes
+					FROM (
+						SELECT key, value FROM json_each(
+							CASE WHEN json_valid(node_pairs.protocol_bytes)
+							     THEN node_pairs.protocol_bytes ELSE '{}' END)
+						UNION ALL
+						SELECT key, value FROM json_each(
+							CASE WHEN json_valid(excluded.protocol_bytes)
+							     THEN excluded.protocol_bytes ELSE '{}' END)
+					) AS protocol_values
+					GROUP BY proto
+					ORDER BY proto
+				)
+			),
+			ports = (
+				SELECT COALESCE(json_group_array(json_object('port', port, 'proto', proto, 'bytes', bytes)), '[]')
+				FROM (
+					SELECT CAST(json_extract(value, '$.port') AS INTEGER) AS port,
+					       CAST(json_extract(value, '$.proto') AS INTEGER) AS proto,
+					       SUM(CAST(json_extract(value, '$.bytes') AS INTEGER)) AS bytes
+					FROM (
+						SELECT value FROM json_each(
+							CASE WHEN json_valid(node_pairs.ports)
+							     THEN node_pairs.ports ELSE '[]' END)
+						UNION ALL
+						SELECT value FROM json_each(
+							CASE WHEN json_valid(excluded.ports)
+							     THEN excluded.ports ELSE '[]' END)
+					) AS port_values
+					GROUP BY proto, port
+					ORDER BY bytes DESC, proto ASC, port ASC
+					LIMIT 20
+				)
+			)
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare node_pairs upsert: %w", err)
@@ -150,7 +229,9 @@ func upsertNodePairsTx(ctx context.Context, tx *sql.Tx, aggregates []NodePairAgg
 		if _, err := stmt.ExecContext(ctx,
 			bucket, agg.SrcNodeID, agg.DstNodeID, agg.TrafficType,
 			agg.TxBytes, agg.RxBytes, agg.TxPkts, agg.RxPkts,
-			agg.FlowCount, agg.Protocols, agg.Ports,
+			agg.FlowCount, agg.Protocols,
+			normalizeProtocolBytes(agg.ProtocolBytes, agg.Protocols, agg.TxBytes+agg.RxBytes),
+			agg.Ports,
 		); err != nil {
 			return fmt.Errorf("failed to upsert node pair: %w", err)
 		}
@@ -229,7 +310,26 @@ func upsertTrafficStatsTx(ctx context.Context, tx *sql.Tx, stats []TrafficStats)
 			physical_bytes    = physical_bytes    + excluded.physical_bytes,
 			total_flows       = total_flows       + excluded.total_flows,
 			unique_pairs      = MAX(unique_pairs, excluded.unique_pairs),
-			top_ports         = excluded.top_ports
+			top_ports         = (
+				SELECT COALESCE(json_group_array(json_object('port', port, 'proto', proto, 'bytes', bytes)), '[]')
+				FROM (
+					SELECT CAST(json_extract(value, '$.port') AS INTEGER) AS port,
+					       CAST(json_extract(value, '$.proto') AS INTEGER) AS proto,
+					       SUM(CAST(json_extract(value, '$.bytes') AS INTEGER)) AS bytes
+					FROM (
+						SELECT value FROM json_each(
+							CASE WHEN json_valid(traffic_stats.top_ports)
+							     THEN traffic_stats.top_ports ELSE '[]' END)
+						UNION ALL
+						SELECT value FROM json_each(
+							CASE WHEN json_valid(excluded.top_ports)
+							     THEN excluded.top_ports ELSE '[]' END)
+					) AS port_values
+					GROUP BY proto, port
+					ORDER BY bytes DESC, proto ASC, port ASC
+					LIMIT 20
+				)
+			)
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare traffic_stats upsert: %w", err)
@@ -284,24 +384,54 @@ func (s *SQLiteStore) GetNodePairAggregates(ctx context.Context, start, end time
 		SELECT MIN(bucket), src_node_id, dst_node_id, traffic_type,
 		       SUM(tx_bytes), SUM(rx_bytes), SUM(tx_pkts), SUM(rx_pkts),
 		       SUM(flow_count),
-		       COALESCE((SELECT protocols FROM node_pairs sub
-		                 WHERE sub.src_node_id = main.src_node_id
-		                   AND sub.dst_node_id = main.dst_node_id
-		                   AND sub.traffic_type = main.traffic_type
-		                   AND sub.bucket >= ? AND sub.bucket <= ?
-		                 ORDER BY sub.bucket DESC LIMIT 1), '[]'),
-		       COALESCE((SELECT ports FROM node_pairs sub
-		                 WHERE sub.src_node_id = main.src_node_id
-		                   AND sub.dst_node_id = main.dst_node_id
-		                   AND sub.traffic_type = main.traffic_type
-		                   AND sub.bucket >= ? AND sub.bucket <= ?
-		                 ORDER BY sub.bucket DESC LIMIT 1), '[]')
+		       COALESCE((SELECT json_group_array(proto) FROM (
+		                    SELECT CAST(j.key AS INTEGER) AS proto,
+		                           SUM(CAST(j.value AS INTEGER)) AS bytes
+		                    FROM node_pairs sub, json_each(
+		                        CASE WHEN json_valid(sub.protocol_bytes)
+		                             THEN sub.protocol_bytes ELSE '{}' END) AS j
+		                    WHERE sub.src_node_id = main.src_node_id
+		                      AND sub.dst_node_id = main.dst_node_id
+		                      AND sub.traffic_type = main.traffic_type
+		                      AND sub.bucket >= ? AND sub.bucket < ?
+		                    GROUP BY proto
+		                    ORDER BY bytes DESC, proto ASC
+		                 )), '[]'),
+		       COALESCE((SELECT json_group_object(proto, bytes) FROM (
+		                    SELECT CAST(j.key AS INTEGER) AS proto,
+		                           SUM(CAST(j.value AS INTEGER)) AS bytes
+		                    FROM node_pairs sub, json_each(
+		                        CASE WHEN json_valid(sub.protocol_bytes)
+		                             THEN sub.protocol_bytes ELSE '{}' END) AS j
+		                    WHERE sub.src_node_id = main.src_node_id
+		                      AND sub.dst_node_id = main.dst_node_id
+		                      AND sub.traffic_type = main.traffic_type
+		                      AND sub.bucket >= ? AND sub.bucket < ?
+		                    GROUP BY proto
+		                    ORDER BY proto ASC
+		                 )), '{}'),
+		       COALESCE((SELECT json_group_array(json_object('port', port, 'proto', proto, 'bytes', bytes)) FROM (
+		                    SELECT CAST(json_extract(j.value, '$.port') AS INTEGER) AS port,
+		                           CAST(json_extract(j.value, '$.proto') AS INTEGER) AS proto,
+		                           SUM(CAST(json_extract(j.value, '$.bytes') AS INTEGER)) AS bytes
+		                    FROM node_pairs sub, json_each(
+		                        CASE WHEN json_valid(sub.ports)
+		                             THEN sub.ports ELSE '[]' END) AS j
+		                    WHERE sub.src_node_id = main.src_node_id
+		                      AND sub.dst_node_id = main.dst_node_id
+		                      AND sub.traffic_type = main.traffic_type
+		                      AND sub.bucket >= ? AND sub.bucket < ?
+		                    GROUP BY proto, port
+		                    ORDER BY bytes DESC, proto ASC, port ASC
+		                    LIMIT 20
+		                 )), '[]')
 		FROM node_pairs main
-		WHERE bucket >= ? AND bucket <= ?
+		WHERE bucket >= ? AND bucket < ?
 		GROUP BY src_node_id, dst_node_id, traffic_type
 		ORDER BY SUM(tx_bytes) + SUM(rx_bytes) DESC
 	`
 	rows, err := s.db.QueryContext(ctx, query,
+		startUnix, endUnix,
 		startUnix, endUnix,
 		startUnix, endUnix,
 		startUnix, endUnix,
@@ -317,7 +447,7 @@ func (s *SQLiteStore) GetNodePairAggregates(ctx context.Context, start, end time
 		if err := rows.Scan(
 			&agg.Bucket, &agg.SrcNodeID, &agg.DstNodeID, &agg.TrafficType,
 			&agg.TxBytes, &agg.RxBytes, &agg.TxPkts, &agg.RxPkts,
-			&agg.FlowCount, &agg.Protocols, &agg.Ports,
+			&agg.FlowCount, &agg.Protocols, &agg.ProtocolBytes, &agg.Ports,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan node pair: %w", err)
 		}
@@ -379,7 +509,7 @@ func (s *SQLiteStore) GetBandwidth(ctx context.Context, start, end time.Time) ([
 	query := fmt.Sprintf(`
 		SELECT (bucket / %d) * %d AS b, SUM(tx_bytes), SUM(rx_bytes)
 		FROM bandwidth
-		WHERE bucket >= ? AND bucket <= ?
+		WHERE bucket >= ? AND bucket < ?
 		GROUP BY b
 		ORDER BY b ASC
 	`, bs, bs)
@@ -422,7 +552,7 @@ func (s *SQLiteStore) GetBandwidthByTrafficTypes(ctx context.Context, start, end
 	query := fmt.Sprintf(`
 		SELECT (bucket / %d) * %d AS b, SUM(tx_bytes), SUM(rx_bytes)
 		FROM node_pairs
-		WHERE bucket >= ? AND bucket <= ? AND traffic_type IN (%s)
+		WHERE bucket >= ? AND bucket < ? AND traffic_type IN (%s)
 		GROUP BY b
 		ORDER BY b ASC
 	`, bs, bs, placeholders)
@@ -467,7 +597,7 @@ func (s *SQLiteStore) GetNodeBandwidth(ctx context.Context, start, end time.Time
 	query := fmt.Sprintf(`
 		SELECT (bucket / %d) * %d AS b, SUM(tx_bytes), SUM(rx_bytes)
 		FROM bandwidth_by_node
-		WHERE bucket >= ? AND bucket <= ? AND node_id = ?
+		WHERE bucket >= ? AND bucket < ? AND node_id = ?
 		GROUP BY b
 		ORDER BY b ASC
 	`, bs, bs)
@@ -522,14 +652,13 @@ func (s *SQLiteStore) GetTrafficStats(ctx context.Context, start, end time.Time)
 	}
 
 	bs := resolveBucketSize(endUnix - startUnix)
-	// top_ports: SQLite picks an arbitrary row's value within each group.
 	query := fmt.Sprintf(`
 		SELECT (bucket / %d) * %d AS b,
 		       SUM(tcp_bytes), SUM(udp_bytes), SUM(other_proto_bytes),
 		       SUM(virtual_bytes), SUM(subnet_bytes), SUM(physical_bytes),
-		       SUM(total_flows), MAX(unique_pairs), top_ports
+		       SUM(total_flows), MAX(unique_pairs)
 		FROM traffic_stats
-		WHERE bucket >= ? AND bucket <= ?
+		WHERE bucket >= ? AND bucket < ?
 		GROUP BY b
 		ORDER BY b ASC
 	`, bs, bs)
@@ -546,13 +675,78 @@ func (s *SQLiteStore) GetTrafficStats(ctx context.Context, start, end time.Time)
 		if err := rows.Scan(
 			&st.Bucket, &st.TCPBytes, &st.UDPBytes, &st.OtherProtoBytes,
 			&st.VirtualBytes, &st.SubnetBytes, &st.PhysicalBytes,
-			&st.TotalFlows, &st.UniquePairs, &st.TopPorts,
+			&st.TotalFlows, &st.UniquePairs,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan traffic stats: %w", err)
 		}
+		st.TopPorts = "[]"
 		results = append(results, st)
 	}
-	return results, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	portQuery := fmt.Sprintf(`
+		WITH port_totals AS (
+			SELECT (ts.bucket / %d) * %d AS b,
+			       CAST(json_extract(p.value, '$.proto') AS INTEGER) AS proto,
+			       CAST(json_extract(p.value, '$.port') AS INTEGER) AS port,
+			       SUM(CAST(json_extract(p.value, '$.bytes') AS INTEGER)) AS bytes
+			FROM traffic_stats ts, json_each(
+				CASE WHEN json_valid(ts.top_ports) THEN ts.top_ports ELSE '[]' END) AS p
+			WHERE ts.bucket >= ? AND ts.bucket < ?
+			GROUP BY b, proto, port
+		), ranked_ports AS (
+			SELECT b, proto, port, bytes,
+			       ROW_NUMBER() OVER (PARTITION BY b ORDER BY bytes DESC, proto ASC, port ASC) AS rn
+			FROM port_totals
+		)
+		SELECT b, proto, port, bytes
+		FROM ranked_ports
+		WHERE rn <= 20
+		ORDER BY b ASC, bytes DESC, proto ASC, port ASC
+	`, bs, bs)
+	portRows, err := s.db.QueryContext(ctx, portQuery, startUnix, endUnix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query traffic stat ports: %w", err)
+	}
+	defer portRows.Close()
+	resultsByBucket := make(map[int64]*TrafficStats, len(results))
+	for i := range results {
+		resultsByBucket[results[i].Bucket] = &results[i]
+	}
+	for portRows.Next() {
+		var bucket int64
+		var port PortStat
+		if err := portRows.Scan(&bucket, &port.Proto, &port.Port, &port.Bytes); err != nil {
+			return nil, fmt.Errorf("failed to scan traffic stat port: %w", err)
+		}
+		if st := resultsByBucket[bucket]; st != nil {
+			st.TopPorts = appendPortStatJSON(st.TopPorts, port)
+		}
+	}
+	if err := portRows.Err(); err != nil {
+		return nil, err
+	}
+	for i := range results {
+		if results[i].TopPorts == "" {
+			results[i].TopPorts = "[]"
+		}
+	}
+	return results, nil
+}
+
+func appendPortStatJSON(raw string, port PortStat) string {
+	var ports []PortStat
+	if json.Unmarshal([]byte(raw), &ports) != nil {
+		ports = nil
+	}
+	ports = append(ports, port)
+	encoded, err := json.Marshal(ports)
+	if err != nil {
+		return "[]"
+	}
+	return string(encoded)
 }
 
 // GetTrafficStatsFromNodePairs synthesizes traffic stats from node_pairs (fallback for old data).
@@ -580,7 +774,7 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 		       SUM(flow_count) AS total_flows,
 		       COUNT(DISTINCT src_node_id || '|' || dst_node_id) AS unique_pairs
 		FROM node_pairs
-		WHERE bucket >= ? AND bucket <= ?%s
+		WHERE bucket >= ? AND bucket < ?%s
 		GROUP BY b, traffic_type
 		ORDER BY b ASC
 	`, bs, bs, typeClause)
@@ -622,45 +816,59 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 		return nil, err
 	}
 
-	// Derive protocol breakdown from protocols JSON column
+	// Derive protocol breakdown from persisted protocol byte totals. The
+	// fallback branch keeps pre-migration rows useful if they are inserted by
+	// an older writer after startup.
 	protoQuery := fmt.Sprintf(`
-		SELECT (bucket / %d) * %d AS b, protocols, SUM(tx_bytes + rx_bytes)
-		FROM node_pairs
-		WHERE bucket >= ? AND bucket <= ? AND traffic_type != 'physical'%s
-		GROUP BY b, protocols
-	`, bs, bs, typeClause)
-	protoRows, err := s.db.QueryContext(ctx, protoQuery, args...)
+		WITH protocol_values AS (
+			SELECT (np.bucket / %d) * %d AS b,
+			       CAST(j.key AS INTEGER) AS proto,
+			       CAST(j.value AS INTEGER) AS bytes
+			FROM node_pairs np, json_each(
+				CASE WHEN json_valid(np.protocol_bytes) AND np.protocol_bytes != '{}'
+				     THEN np.protocol_bytes ELSE '{}' END) AS j
+			WHERE np.bucket >= ? AND np.bucket < ? AND np.traffic_type != 'physical'%s
+			UNION ALL
+			SELECT (np.bucket / %d) * %d AS b,
+			       CAST(j.value AS INTEGER) AS proto,
+			       (np.tx_bytes + np.rx_bytes) / json_array_length(np.protocols)
+			       + CASE WHEN CAST(j.key AS INTEGER) = 0 THEN
+				           (np.tx_bytes + np.rx_bytes) -
+				           ((np.tx_bytes + np.rx_bytes) / json_array_length(np.protocols)) * json_array_length(np.protocols)
+				         ELSE 0 END AS bytes
+			FROM node_pairs np, json_each(
+				CASE WHEN json_valid(np.protocols) THEN np.protocols ELSE '[]' END) AS j
+			WHERE np.bucket >= ? AND np.bucket < ? AND np.traffic_type != 'physical'%s
+			  AND (np.protocol_bytes IS NULL OR np.protocol_bytes = '' OR np.protocol_bytes = '{}')
+			  AND json_array_length(CASE WHEN json_valid(np.protocols) THEN np.protocols ELSE '[]' END) > 0
+		)
+		SELECT b, proto, SUM(bytes)
+		FROM protocol_values
+		GROUP BY b, proto
+	`, bs, bs, typeClause, bs, bs, typeClause)
+	protoArgs := append([]any{startUnix, endUnix}, typeArgs...)
+	protoArgs = append(protoArgs, startUnix, endUnix)
+	protoArgs = append(protoArgs, typeArgs...)
+	protoRows, err := s.db.QueryContext(ctx, protoQuery, protoArgs...)
 	if err == nil {
 		for protoRows.Next() {
 			var b int64
-			var protosJSON string
+			var protocol int
 			var totalBytes int64
-			if err := protoRows.Scan(&b, &protosJSON, &totalBytes); err != nil {
+			if err := protoRows.Scan(&b, &protocol, &totalBytes); err != nil {
 				continue
 			}
 			st, ok := bucketMap[b]
 			if !ok {
 				continue
 			}
-			var protos []int
-			if err := json.Unmarshal([]byte(protosJSON), &protos); err != nil || len(protos) == 0 {
-				continue
-			}
-			perProto := totalBytes / int64(len(protos))
-			rem := totalBytes - perProto*int64(len(protos))
-			for i, p := range protos {
-				share := perProto
-				if i == 0 {
-					share += rem
-				}
-				switch p {
-				case 6:
-					st.TCPBytes += share
-				case 17:
-					st.UDPBytes += share
-				default:
-					st.OtherProtoBytes += share
-				}
+			switch protocol {
+			case 6:
+				st.TCPBytes += totalBytes
+			case 17:
+				st.UDPBytes += totalBytes
+			default:
+				st.OtherProtoBytes += totalBytes
 			}
 		}
 		protoRows.Close()
@@ -675,20 +883,21 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 			       CAST(json_extract(p.value, '$.proto') AS INTEGER) AS proto,
 			       CAST(json_extract(p.value, '$.port') AS INTEGER) AS port,
 			       SUM(CAST(json_extract(p.value, '$.bytes') AS INTEGER)) AS bytes
-			FROM node_pairs, json_each(ports) AS p
-			WHERE bucket >= ? AND bucket <= ?%s
+			FROM node_pairs, json_each(
+				CASE WHEN json_valid(ports) THEN ports ELSE '[]' END) AS p
+			WHERE bucket >= ? AND bucket < ?%s
 			  AND ports != '[]'
 			GROUP BY b, proto, port
 		),
 		ranked_ports AS (
 			SELECT b, proto, port, bytes,
-			       ROW_NUMBER() OVER (PARTITION BY b ORDER BY bytes DESC) AS rn
+			       ROW_NUMBER() OVER (PARTITION BY b ORDER BY bytes DESC, proto ASC, port ASC) AS rn
 			FROM port_totals
 		)
 		SELECT b, proto, port, bytes
 		FROM ranked_ports
 		WHERE rn <= 20
-		ORDER BY b ASC, bytes DESC
+			ORDER BY b ASC, bytes DESC, proto ASC, port ASC
 	`, bs, bs, typeClause)
 	portRows, err := s.db.QueryContext(ctx, portQuery, args...)
 	if err == nil {
@@ -735,9 +944,9 @@ func (s *SQLiteStore) GetTopTalkers(ctx context.Context, start, end time.Time, l
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT node_id, SUM(tx_bytes), SUM(rx_bytes), SUM(tx_bytes + rx_bytes) AS total
 		FROM bandwidth_by_node
-		WHERE bucket >= ? AND bucket <= ?
+		WHERE bucket >= ? AND bucket < ?
 		GROUP BY node_id
-		ORDER BY total DESC
+		ORDER BY total DESC, node_id ASC
 		LIMIT ?
 	`, startUnix, endUnix, limit)
 	if err != nil {
@@ -775,18 +984,18 @@ func (s *SQLiteStore) GetTopTalkersByTrafficTypes(ctx context.Context, start, en
 		WITH node_bytes AS (
 			SELECT src_node_id AS node_id, SUM(tx_bytes) AS tx, SUM(rx_bytes) AS rx
 			FROM node_pairs
-			WHERE bucket >= ? AND bucket <= ?%s
+			WHERE bucket >= ? AND bucket < ?%s
 			GROUP BY src_node_id
 			UNION ALL
 			SELECT dst_node_id AS node_id, SUM(rx_bytes) AS tx, SUM(tx_bytes) AS rx
 			FROM node_pairs
-			WHERE bucket >= ? AND bucket <= ?%s
+			WHERE bucket >= ? AND bucket < ?%s
 			GROUP BY dst_node_id
 		)
 		SELECT node_id, SUM(tx) AS tx, SUM(rx) AS rx, SUM(tx + rx) AS total
 		FROM node_bytes
 		GROUP BY node_id
-		ORDER BY total DESC
+		ORDER BY total DESC, node_id ASC
 		LIMIT ?
 	`, typeClause, typeClause)
 	args := append([]any{startUnix, endUnix}, typeArgs...)
@@ -830,9 +1039,9 @@ func (s *SQLiteStore) GetTopPairs(ctx context.Context, start, end time.Time, lim
 		       SUM(tx_bytes), SUM(rx_bytes),
 		       SUM(tx_bytes + rx_bytes) AS total, SUM(flow_count)
 		FROM node_pairs
-		WHERE bucket >= ? AND bucket <= ?
+		WHERE bucket >= ? AND bucket < ?
 		GROUP BY src_node_id, dst_node_id
-		ORDER BY total DESC
+		ORDER BY total DESC, src_node_id ASC, dst_node_id ASC
 		LIMIT ?
 	`, startUnix, endUnix, limit)
 	if err != nil {
@@ -871,9 +1080,9 @@ func (s *SQLiteStore) GetTopPairsByTrafficTypes(ctx context.Context, start, end 
 		       SUM(tx_bytes), SUM(rx_bytes),
 		       SUM(tx_bytes + rx_bytes) AS total, SUM(flow_count)
 		FROM node_pairs
-		WHERE bucket >= ? AND bucket <= ?%s
+		WHERE bucket >= ? AND bucket < ?%s
 		GROUP BY src_node_id, dst_node_id
-		ORDER BY total DESC
+		ORDER BY total DESC, src_node_id ASC, dst_node_id ASC
 		LIMIT ?
 	`, typeClause)
 	args := append([]any{startUnix, endUnix}, typeArgs...)
@@ -928,7 +1137,7 @@ func (s *SQLiteStore) GetNodeStats(ctx context.Context, nodeID string, start, en
 	if err := s.db.QueryRowContext(ctx, `
 		SELECT COALESCE(SUM(tx_bytes), 0), COALESCE(SUM(rx_bytes), 0)
 		FROM bandwidth_by_node
-		WHERE node_id = ? AND bucket >= ? AND bucket <= ?
+		WHERE node_id = ? AND bucket >= ? AND bucket < ?
 	`, nodeID, startUnix, endUnix).Scan(&result.TotalTx, &result.TotalRx); err != nil {
 		return nil, fmt.Errorf("failed to query node bandwidth: %w", err)
 	}
@@ -938,12 +1147,12 @@ func (s *SQLiteStore) GetNodeStats(ctx context.Context, nodeID string, start, en
 		FROM (
 			SELECT dst_node_id AS peer_id, SUM(tx_bytes) AS tx, SUM(rx_bytes) AS rx, SUM(flow_count) AS fc
 			FROM node_pairs
-			WHERE src_node_id = ? AND bucket >= ? AND bucket <= ?
+			WHERE src_node_id = ? AND bucket >= ? AND bucket < ?
 			GROUP BY dst_node_id
 			UNION ALL
 			SELECT src_node_id AS peer_id, SUM(rx_bytes) AS tx, SUM(tx_bytes) AS rx, SUM(flow_count) AS fc
 			FROM node_pairs
-			WHERE dst_node_id = ? AND bucket >= ? AND bucket <= ?
+			WHERE dst_node_id = ? AND bucket >= ? AND bucket < ?
 			GROUP BY src_node_id
 		)
 		GROUP BY peer_id
@@ -969,7 +1178,7 @@ func (s *SQLiteStore) GetNodeStats(ctx context.Context, nodeID string, start, en
 	portRows, err := s.db.QueryContext(ctx, `
 		SELECT ports FROM node_pairs
 		WHERE (src_node_id = ? OR dst_node_id = ?)
-		  AND bucket >= ? AND bucket <= ?
+		  AND bucket >= ? AND bucket < ?
 		  AND ports != '[]'
 	`, nodeID, nodeID, startUnix, endUnix)
 	if err != nil {
@@ -1003,7 +1212,15 @@ func (s *SQLiteStore) GetNodeStats(ctx context.Context, nodeID string, start, en
 		}
 		result.TopPorts = append(result.TopPorts, PortStat{Port: ppk.port, Proto: ppk.proto, Bytes: bytes})
 	}
-	sort.Slice(result.TopPorts, func(i, j int) bool { return result.TopPorts[i].Bytes > result.TopPorts[j].Bytes })
+	sort.Slice(result.TopPorts, func(i, j int) bool {
+		if result.TopPorts[i].Bytes != result.TopPorts[j].Bytes {
+			return result.TopPorts[i].Bytes > result.TopPorts[j].Bytes
+		}
+		if result.TopPorts[i].Proto != result.TopPorts[j].Proto {
+			return result.TopPorts[i].Proto < result.TopPorts[j].Proto
+		}
+		return result.TopPorts[i].Port < result.TopPorts[j].Port
+	})
 	if len(result.TopPorts) > 15 {
 		result.TopPorts = result.TopPorts[:15]
 	}

--- a/backend/internal/database/aggregate_queries.go
+++ b/backend/internal/database/aggregate_queries.go
@@ -155,17 +155,22 @@ func (s *SQLiteStore) CommitObjectIngest(ctx context.Context, result ObjectInges
 		return err
 	}
 
-	_, err = tx.ExecContext(ctx,
-		`UPDATE poll_state
-		 SET last_poll_end = CASE
-		       WHEN last_poll_end IS NULL OR last_poll_end = '' OR datetime(last_poll_end) IS NULL OR datetime(last_poll_end) < datetime(?)
-		       THEN ? ELSE last_poll_end END,
-		     updated_at = CURRENT_TIMESTAMP
-		 WHERE id = 1`,
-		result.PollEnd.UTC().Format(sqliteFormat), result.PollEnd.UTC().Format(sqliteFormat),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to update poll state: %w", err)
+	// Object-store polls update the cursor after the full object batch has been
+	// examined. Leaving PollEnd zero keeps an unreadable earlier object from
+	// being skipped when a later object was committed successfully.
+	if !result.PollEnd.IsZero() {
+		_, err = tx.ExecContext(ctx,
+			`UPDATE poll_state
+			 SET last_poll_end = CASE
+			       WHEN last_poll_end IS NULL OR last_poll_end = '' OR datetime(last_poll_end) IS NULL OR datetime(last_poll_end) < datetime(?)
+			       THEN ? ELSE last_poll_end END,
+			     updated_at = CURRENT_TIMESTAMP
+			 WHERE id = 1`,
+			result.PollEnd.UTC().Format(sqliteFormat), result.PollEnd.UTC().Format(sqliteFormat),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to update poll state: %w", err)
+		}
 	}
 
 	return tx.Commit()
@@ -327,9 +332,9 @@ func upsertTrafficStatsTx(ctx context.Context, tx *sql.Tx, stats []TrafficStats)
 
 	stmt, err := tx.PrepareContext(ctx, `
 		INSERT INTO traffic_stats (bucket, tcp_bytes, udp_bytes, other_proto_bytes,
-		                           virtual_bytes, subnet_bytes, physical_bytes,
+		                           virtual_bytes, exit_bytes, subnet_bytes, physical_bytes,
 		                           total_flows, unique_pairs, top_ports)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(bucket) DO UPDATE SET
 			tcp_bytes         = tcp_bytes         + excluded.tcp_bytes,
 			udp_bytes         = udp_bytes         + excluded.udp_bytes,
@@ -337,6 +342,7 @@ func upsertTrafficStatsTx(ctx context.Context, tx *sql.Tx, stats []TrafficStats)
 			virtual_bytes     = virtual_bytes     + excluded.virtual_bytes,
 			subnet_bytes      = subnet_bytes      + excluded.subnet_bytes,
 			physical_bytes    = physical_bytes    + excluded.physical_bytes,
+			exit_bytes       = COALESCE(exit_bytes, 0) + excluded.exit_bytes,
 			total_flows       = total_flows       + excluded.total_flows,
 			unique_pairs      = MAX(unique_pairs, excluded.unique_pairs),
 			top_ports         = (
@@ -370,7 +376,7 @@ func upsertTrafficStatsTx(ctx context.Context, tx *sql.Tx, stats []TrafficStats)
 		bucket := (st.Bucket / bucketSize) * bucketSize
 		if _, err := stmt.ExecContext(ctx,
 			bucket, st.TCPBytes, st.UDPBytes, st.OtherProtoBytes,
-			st.VirtualBytes, st.SubnetBytes, st.PhysicalBytes,
+			st.VirtualBytes, st.ExitBytes, st.SubnetBytes, st.PhysicalBytes,
 			st.TotalFlows, st.UniquePairs, st.TopPorts,
 		); err != nil {
 			return fmt.Errorf("failed to upsert traffic stats: %w", err)
@@ -580,7 +586,7 @@ func (s *SQLiteStore) GetBandwidthByTrafficTypes(ctx context.Context, start, end
 	bs := resolveBucketSize(endUnix - startUnix)
 	placeholders := strings.TrimRight(strings.Repeat("?,", len(trafficTypes)), ",")
 	query := fmt.Sprintf(`
-		SELECT (bucket / %d) * %d AS b, SUM(tx_bytes), SUM(rx_bytes)
+		SELECT (bucket / %d) * %d AS b, SUM(tx_bytes + rx_bytes), 0
 		FROM node_pairs
 		WHERE bucket >= ? AND bucket < ? AND traffic_type IN (%s)
 		GROUP BY b
@@ -623,16 +629,37 @@ func (s *SQLiteStore) GetNodeBandwidth(ctx context.Context, start, end time.Time
 		return nil, fmt.Errorf("invalid time range: start (%v) must be before end (%v)", start, end)
 	}
 
+	// Derive node bandwidth from normalized node_pairs rather than the legacy
+	// bandwidth_by_node table. This keeps historical self-flows from appearing
+	// as both TX and RX after the self-flow accounting fix.
 	bs := resolveBucketSize(endUnix - startUnix)
 	query := fmt.Sprintf(`
-		SELECT (bucket / %d) * %d AS b, SUM(tx_bytes), SUM(rx_bytes)
-		FROM bandwidth_by_node
-		WHERE bucket >= ? AND bucket < ? AND node_id = ?
+		WITH node_bytes AS (
+			SELECT (bucket / %d) * %d AS b,
+			       src_node_id AS node_id,
+			       SUM(tx_bytes) AS tx,
+			       SUM(rx_bytes) AS rx
+			FROM node_pairs
+			WHERE bucket >= ? AND bucket < ?
+			GROUP BY b, src_node_id
+			UNION ALL
+			SELECT (bucket / %d) * %d AS b,
+			       dst_node_id AS node_id,
+			       SUM(rx_bytes) AS tx,
+			       SUM(tx_bytes) AS rx
+			FROM node_pairs
+			WHERE bucket >= ? AND bucket < ?
+			  AND src_node_id != dst_node_id
+			GROUP BY b, dst_node_id
+		)
+		SELECT b, SUM(tx), SUM(rx)
+		FROM node_bytes
+		WHERE node_id = ?
 		GROUP BY b
 		ORDER BY b ASC
-	`, bs, bs)
+	`, bs, bs, bs, bs)
 
-	rows, err := s.db.QueryContext(ctx, query, startUnix, endUnix, nodeID)
+	rows, err := s.db.QueryContext(ctx, query, startUnix, endUnix, startUnix, endUnix, nodeID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query node bandwidth: %w", err)
 	}
@@ -689,6 +716,7 @@ func (s *SQLiteStore) GetTrafficStats(ctx context.Context, start, end time.Time)
 			       SUM(udp_bytes) AS udp_bytes,
 			       SUM(other_proto_bytes) AS other_proto_bytes,
 			       SUM(virtual_bytes) AS virtual_bytes,
+			       SUM(exit_bytes) AS exit_bytes,
 			       SUM(subnet_bytes) AS subnet_bytes,
 			       SUM(physical_bytes) AS physical_bytes,
 			       SUM(total_flows) AS total_flows,
@@ -707,7 +735,7 @@ func (s *SQLiteStore) GetTrafficStats(ctx context.Context, start, end time.Time)
 			GROUP BY b
 		)
 		SELECT sb.b, sb.tcp_bytes, sb.udp_bytes, sb.other_proto_bytes,
-		       sb.virtual_bytes, sb.subnet_bytes, sb.physical_bytes,
+		       sb.virtual_bytes, sb.exit_bytes, sb.subnet_bytes, sb.physical_bytes,
 		       sb.total_flows,
 		       MAX(COALESCE(pb.unique_pairs, 0), COALESCE(sb.stored_unique_pairs, 0))
 		FROM stat_buckets sb
@@ -726,7 +754,7 @@ func (s *SQLiteStore) GetTrafficStats(ctx context.Context, start, end time.Time)
 		var st TrafficStats
 		if err := rows.Scan(
 			&st.Bucket, &st.TCPBytes, &st.UDPBytes, &st.OtherProtoBytes,
-			&st.VirtualBytes, &st.SubnetBytes, &st.PhysicalBytes,
+			&st.VirtualBytes, &st.ExitBytes, &st.SubnetBytes, &st.PhysicalBytes,
 			&st.TotalFlows, &st.UniquePairs,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan traffic stats: %w", err)
@@ -822,8 +850,10 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 	typeClause, typeArgs := trafficTypeWhereClause(trafficTypes)
 	query := fmt.Sprintf(`
 		SELECT (bucket / %d) * %d AS b,
-		       SUM(CASE WHEN traffic_type IN ('virtual', 'exit')
+		       SUM(CASE WHEN traffic_type = 'virtual'
 		                THEN tx_bytes + rx_bytes ELSE 0 END) AS virtual_bytes,
+		       SUM(CASE WHEN traffic_type = 'exit'
+		                THEN tx_bytes + rx_bytes ELSE 0 END) AS exit_bytes,
 		       SUM(CASE WHEN traffic_type = 'subnet'
 		                THEN tx_bytes + rx_bytes ELSE 0 END) AS subnet_bytes,
 		       SUM(CASE WHEN traffic_type = 'physical'
@@ -846,8 +876,8 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 	bucketMap := make(map[int64]*TrafficStats)
 	for rows.Next() {
 		var bucket int64
-		var virtualBytes, subnetBytes, physicalBytes, totalFlows, uniquePairs int64
-		if err := rows.Scan(&bucket, &virtualBytes, &subnetBytes, &physicalBytes, &totalFlows, &uniquePairs); err != nil {
+		var virtualBytes, exitBytes, subnetBytes, physicalBytes, totalFlows, uniquePairs int64
+		if err := rows.Scan(&bucket, &virtualBytes, &exitBytes, &subnetBytes, &physicalBytes, &totalFlows, &uniquePairs); err != nil {
 			return nil, fmt.Errorf("failed to scan: %w", err)
 		}
 		st, ok := bucketMap[bucket]
@@ -856,6 +886,7 @@ func (s *SQLiteStore) GetTrafficStatsFromNodePairsByTrafficTypes(ctx context.Con
 			bucketMap[bucket] = st
 		}
 		st.VirtualBytes = virtualBytes
+		st.ExitBytes = exitBytes
 		st.SubnetBytes = subnetBytes
 		st.PhysicalBytes = physicalBytes
 		st.TotalFlows += totalFlows
@@ -1009,14 +1040,30 @@ func (s *SQLiteStore) GetTopTalkers(ctx context.Context, start, end time.Time, l
 		limit = 10
 	}
 
+	// Use node_pairs as the source of truth so old per-node rows cannot retain
+	// the pre-fix self-flow double count.
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT node_id, SUM(tx_bytes), SUM(rx_bytes), SUM(tx_bytes + rx_bytes) AS total
-		FROM bandwidth_by_node
-		WHERE bucket >= ? AND bucket < ?
-		GROUP BY node_id
+		WITH node_bytes AS (
+			SELECT src_node_id AS node_id, SUM(tx_bytes) AS tx, SUM(rx_bytes) AS rx
+			FROM node_pairs
+			WHERE bucket >= ? AND bucket < ?
+			GROUP BY src_node_id
+			UNION ALL
+			SELECT dst_node_id AS node_id, SUM(rx_bytes) AS tx, SUM(tx_bytes) AS rx
+			FROM node_pairs
+			WHERE bucket >= ? AND bucket < ?
+			  AND src_node_id != dst_node_id
+			GROUP BY dst_node_id
+		), totals AS (
+			SELECT node_id, SUM(tx) AS tx, SUM(rx) AS rx
+			FROM node_bytes
+			GROUP BY node_id
+		)
+		SELECT node_id, tx, rx, tx + rx AS total
+		FROM totals
 		ORDER BY total DESC, node_id ASC
 		LIMIT ?
-	`, startUnix, endUnix, limit)
+	`, startUnix, endUnix, startUnix, endUnix, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query top talkers: %w", err)
 	}
@@ -1203,11 +1250,22 @@ func (s *SQLiteStore) GetNodeStats(ctx context.Context, nodeID string, start, en
 		TopPorts: make([]PortStat, 0),
 	}
 
+	// Keep totals consistent with GetNodeBandwidth and GetTopTalkers: derive
+	// them from normalized pairs instead of legacy per-node bandwidth rows.
 	if err := s.db.QueryRowContext(ctx, `
-		SELECT COALESCE(SUM(tx_bytes), 0), COALESCE(SUM(rx_bytes), 0)
-		FROM bandwidth_by_node
-		WHERE node_id = ? AND bucket >= ? AND bucket < ?
-	`, nodeID, startUnix, endUnix).Scan(&result.TotalTx, &result.TotalRx); err != nil {
+		WITH node_bytes AS (
+			SELECT SUM(tx_bytes) AS tx, SUM(rx_bytes) AS rx
+			FROM node_pairs
+			WHERE src_node_id = ? AND bucket >= ? AND bucket < ?
+			UNION ALL
+			SELECT SUM(rx_bytes) AS tx, SUM(tx_bytes) AS rx
+			FROM node_pairs
+			WHERE dst_node_id = ? AND bucket >= ? AND bucket < ?
+			  AND src_node_id != dst_node_id
+		)
+		SELECT COALESCE(SUM(tx), 0), COALESCE(SUM(rx), 0)
+		FROM node_bytes
+	`, nodeID, startUnix, endUnix, nodeID, startUnix, endUnix).Scan(&result.TotalTx, &result.TotalRx); err != nil {
 		return nil, fmt.Errorf("failed to query node bandwidth: %w", err)
 	}
 

--- a/backend/internal/database/aggregate_queries_test.go
+++ b/backend/internal/database/aggregate_queries_test.go
@@ -146,6 +146,30 @@ func TestDerivedTrafficStatsUnionPairsAcrossTrafficTypes(t *testing.T) {
 	}
 }
 
+func TestDerivedTrafficStatsFallsBackForMalformedProtocolBytes(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO node_pairs
+			(bucket, src_node_id, dst_node_id, traffic_type, tx_bytes, protocols, protocol_bytes)
+		VALUES (?, 'a', 'b', 'virtual', 100, '[6,17]', 'not-json')
+	`, base); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := store.GetTrafficStatsFromNodePairs(ctx, time.Unix(base, 0), time.Unix(base+60, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("stats = %+v, want one bucket", stats)
+	}
+	if stats[0].TCPBytes != 50 || stats[0].UDPBytes != 50 {
+		t.Fatalf("protocol stats = %+v, want 50 TCP and 50 UDP", stats[0])
+	}
+}
+
 func TestTrafficStatsRecomputesUniquePairsFromNodePairs(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()

--- a/backend/internal/database/aggregate_queries_test.go
+++ b/backend/internal/database/aggregate_queries_test.go
@@ -147,6 +147,29 @@ func TestDerivedTrafficStatsUnionPairsAcrossTrafficTypes(t *testing.T) {
 	}
 }
 
+func TestDerivedTrafficStatsDistinguishesDelimiterContainingPairs(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{
+		{Bucket: base, SrcNodeID: "a|b", DstNodeID: "c", TrafficType: "virtual", TxBytes: 100, FlowCount: 1, Protocols: "[6]", ProtocolBytes: `{"6":100}`},
+		{Bucket: base, SrcNodeID: "a", DstNodeID: "b|c", TrafficType: "virtual", TxBytes: 200, FlowCount: 1, Protocols: "[17]", ProtocolBytes: `{"17":200}`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := store.GetTrafficStatsFromNodePairs(ctx, time.Unix(base, 0), time.Unix(base+60, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("stats = %+v, want one bucket", stats)
+	}
+	if stats[0].VirtualBytes != 300 || stats[0].TotalFlows != 2 || stats[0].UniquePairs != 2 {
+		t.Fatalf("stats = %+v, want 300 virtual bytes, two flows, and two unique pairs", stats[0])
+	}
+}
+
 func TestDerivedTrafficStatsFallsBackForMalformedProtocolBytes(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()

--- a/backend/internal/database/aggregate_queries_test.go
+++ b/backend/internal/database/aggregate_queries_test.go
@@ -114,3 +114,59 @@ func TestTrafficStatsUpsertMergesTopPorts(t *testing.T) {
 		t.Fatalf("top ports = %+v", ports)
 	}
 }
+
+func TestDerivedTrafficStatsUnionPairsAcrossTrafficTypes(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{
+		{Bucket: base, SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual", TxBytes: 100, FlowCount: 2, Protocols: "[6]", ProtocolBytes: `{"6":100}`},
+		{Bucket: base, SrcNodeID: "c", DstNodeID: "d", TrafficType: "subnet", TxBytes: 200, FlowCount: 3, Protocols: "[17]", ProtocolBytes: `{"17":200}`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := store.GetTrafficStatsFromNodePairs(ctx, time.Unix(base, 0), time.Unix(base+60, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("stats = %+v, want one bucket", stats)
+	}
+	if stats[0].VirtualBytes != 100 || stats[0].SubnetBytes != 200 || stats[0].TotalFlows != 5 || stats[0].UniquePairs != 2 {
+		t.Fatalf("stats = %+v", stats[0])
+	}
+
+	filtered, err := store.GetTrafficStatsFromNodePairsByTrafficTypes(ctx, time.Unix(base, 0), time.Unix(base+60, 0), []string{"virtual"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 1 || filtered[0].VirtualBytes != 100 || filtered[0].SubnetBytes != 0 || filtered[0].UniquePairs != 1 {
+		t.Fatalf("filtered stats = %+v", filtered)
+	}
+}
+
+func TestTrafficStatsRecomputesUniquePairsFromNodePairs(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{
+		{Bucket: base, SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual", TxBytes: 100, Protocols: "[6]", ProtocolBytes: `{"6":100}`},
+		{Bucket: base, SrcNodeID: "c", DstNodeID: "d", TrafficType: "subnet", TxBytes: 200, Protocols: "[17]", ProtocolBytes: `{"17":200}`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertTrafficStats(ctx, []TrafficStats{{
+		Bucket: base, TCPBytes: 100, TotalFlows: 2, UniquePairs: 1,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := store.GetTrafficStats(ctx, time.Unix(base, 0), time.Unix(base+60, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats) != 1 || stats[0].UniquePairs != 2 {
+		t.Fatalf("stats = %+v, want two unique pairs", stats)
+	}
+}

--- a/backend/internal/database/aggregate_queries_test.go
+++ b/backend/internal/database/aggregate_queries_test.go
@@ -32,7 +32,7 @@ func TestAggregateQueriesUseHalfOpenRangesAndMergeMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	aggregates, err := store.GetNodePairAggregates(ctx, time.Unix(base, 0), time.Unix(base+120, 0), 60)
+	aggregates, err := store.GetNodePairAggregates(ctx, time.Unix(base, 0), time.Unix(base+120, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestAggregateQueriesUseHalfOpenRangesAndMergeMetadata(t *testing.T) {
 		t.Fatalf("ports = %+v", ports)
 	}
 
-	boundary, err := store.GetNodePairAggregates(ctx, time.Unix(base+120, 0), time.Unix(base+180, 0), 60)
+	boundary, err := store.GetNodePairAggregates(ctx, time.Unix(base+120, 0), time.Unix(base+180, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,6 +167,26 @@ func TestDerivedTrafficStatsFallsBackForMalformedProtocolBytes(t *testing.T) {
 	}
 	if stats[0].TCPBytes != 50 || stats[0].UDPBytes != 50 {
 		t.Fatalf("protocol stats = %+v, want 50 TCP and 50 UDP", stats[0])
+	}
+}
+
+func TestDerivedTrafficStatsIncludesPhysicalProtocolBytes(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{
+		{Bucket: base, SrcNodeID: "a", DstNodeID: "b", TrafficType: "physical", TxBytes: 125, Protocols: "[6]", ProtocolBytes: `{"6":125}`},
+		{Bucket: base, SrcNodeID: "c", DstNodeID: "d", TrafficType: "virtual", TxBytes: 50, Protocols: "[17]", ProtocolBytes: `{"17":50}`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := store.GetTrafficStatsFromNodePairs(ctx, time.Unix(base, 0), time.Unix(base+60, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats) != 1 || stats[0].TCPBytes != 125 || stats[0].UDPBytes != 50 || stats[0].PhysicalBytes != 125 {
+		t.Fatalf("stats = %+v, want physical TCP bytes included", stats)
 	}
 }
 

--- a/backend/internal/database/aggregate_queries_test.go
+++ b/backend/internal/database/aggregate_queries_test.go
@@ -191,6 +191,54 @@ func TestDerivedTrafficStatsIncludesPhysicalProtocolBytes(t *testing.T) {
 	}
 }
 
+func TestDerivedTrafficStatsKeepsExitBytesSeparateFromVirtual(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{
+		{Bucket: base, SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual", TxBytes: 100, Protocols: "[6]", ProtocolBytes: `{"6":100}`},
+		{Bucket: base, SrcNodeID: "c", DstNodeID: "d", TrafficType: "exit", TxBytes: 40, Protocols: "[17]", ProtocolBytes: `{"17":40}`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := store.GetTrafficStatsFromNodePairs(ctx, time.Unix(base, 0), time.Unix(base+60, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats) != 1 || stats[0].VirtualBytes != 100 || stats[0].ExitBytes != 40 {
+		t.Fatalf("traffic stats = %+v, want virtual 100 and exit 40", stats[0])
+	}
+
+	filtered, err := store.GetTrafficStatsFromNodePairsByTrafficTypes(ctx, time.Unix(base, 0), time.Unix(base+60, 0), []string{"exit"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 1 || filtered[0].VirtualBytes != 0 || filtered[0].ExitBytes != 40 {
+		t.Fatalf("filtered exit stats = %+v, want virtual 0 and exit 40", filtered[0])
+	}
+}
+
+func TestGetBandwidthByTrafficTypesUsesPairTotalOnce(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{{
+		Bucket: base, SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+		TxBytes: 100, RxBytes: 40, Protocols: "[6]", ProtocolBytes: `{"6":140}`,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	buckets, err := store.GetBandwidthByTrafficTypes(ctx, time.Unix(base, 0), time.Unix(base+60, 0), []string{"virtual"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(buckets) != 1 || buckets[0].TxBytes != 140 || buckets[0].RxBytes != 0 {
+		t.Fatalf("filtered bandwidth = %+v, want one 140-byte TX bucket", buckets)
+	}
+}
+
 func TestTrafficStatsRecomputesUniquePairsFromNodePairs(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()
@@ -279,5 +327,86 @@ func TestGetTopTalkersByTrafficTypesDoesNotDoubleCountSelfTraffic(t *testing.T) 
 	if len(talkers) != 1 || talkers[0].NodeID != "a" ||
 		talkers[0].TxBytes != 100 || talkers[0].RxBytes != 50 || talkers[0].TotalBytes != 150 {
 		t.Fatalf("self talker stats = %+v, want one unduplicated self row", talkers)
+	}
+}
+
+func TestGetTopTalkersDoesNotDoubleCountSelfTraffic(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{{
+		Bucket: base, SrcNodeID: "a", DstNodeID: "a", TrafficType: "virtual",
+		TxBytes: 100, RxBytes: 0, FlowCount: 1, Protocols: "[6]", ProtocolBytes: `{"6":100}`, Ports: "[]",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertNodeBandwidth(ctx, []NodeBandwidth{{
+		Bucket: base, NodeID: "a", TxBytes: 100, RxBytes: 50,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	talkers, err := store.GetTopTalkers(ctx, time.Unix(base, 0), time.Unix(base+60, 0), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(talkers) != 1 || talkers[0].NodeID != "a" ||
+		talkers[0].TxBytes != 100 || talkers[0].RxBytes != 0 || talkers[0].TotalBytes != 100 {
+		t.Fatalf("self talker stats = %+v, want one normalized self row", talkers)
+	}
+}
+
+func TestNodeBandwidthAndStatsDeriveFromPairsInsteadOfLegacyNodeRows(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{
+		{Bucket: base, SrcNodeID: "a", DstNodeID: "a", TrafficType: "virtual", TxBytes: 100, RxBytes: 0, FlowCount: 1, Protocols: "[6]", ProtocolBytes: `{"6":100}`, Ports: "[]"},
+		{Bucket: base, SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual", TxBytes: 25, RxBytes: 5, FlowCount: 1, Protocols: "[6]", ProtocolBytes: `{"6":30}`, Ports: "[]"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a legacy row from the old self-flow accounting, where the same
+	// 100 bytes were stored once as TX and again as RX.
+	if err := store.UpsertNodeBandwidth(ctx, []NodeBandwidth{{
+		Bucket: base, NodeID: "a", TxBytes: 125, RxBytes: 105,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	buckets, err := store.GetNodeBandwidth(ctx, time.Unix(base, 0), time.Unix(base+60, 0), "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(buckets) != 1 || buckets[0].TxBytes != 125 || buckets[0].RxBytes != 5 {
+		t.Fatalf("node bandwidth = %+v, want TX 125 RX 5 from normalized pairs", buckets)
+	}
+
+	stats, err := store.GetNodeStats(ctx, "a", time.Unix(base, 0), time.Unix(base+60, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.TotalTx != 125 || stats.TotalRx != 5 {
+		t.Fatalf("node totals = TX %d RX %d, want 125 and 5", stats.TotalTx, stats.TotalRx)
+	}
+}
+
+func TestNodeBandwidthAndStatsUseCoarseBucketTotals(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{
+		{Bucket: base, SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual", TxBytes: 10, RxBytes: 2, Protocols: "[6]", ProtocolBytes: `{"6":12}`, Ports: "[]"},
+		{Bucket: base + 60, SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual", TxBytes: 20, RxBytes: 3, Protocols: "[6]", ProtocolBytes: `{"6":23}`, Ports: "[]"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	buckets, err := store.GetNodeBandwidth(ctx, time.Unix(base, 0), time.Unix(base+2*60, 0), "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(buckets) != 2 || buckets[0].TxBytes != 10 || buckets[0].RxBytes != 2 || buckets[1].TxBytes != 20 || buckets[1].RxBytes != 3 {
+		t.Fatalf("node bandwidth buckets = %+v, want separate minute totals", buckets)
 	}
 }

--- a/backend/internal/database/aggregate_queries_test.go
+++ b/backend/internal/database/aggregate_queries_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -212,5 +213,50 @@ func TestTrafficStatsRecomputesUniquePairsFromNodePairs(t *testing.T) {
 	}
 	if len(stats) != 1 || stats[0].UniquePairs != 2 {
 		t.Fatalf("stats = %+v, want two unique pairs", stats)
+	}
+}
+
+func TestGetNodeStatsPropagatesMalformedPortJSON(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO node_pairs
+			(bucket, src_node_id, dst_node_id, traffic_type, tx_bytes, ports)
+		VALUES (?, 'a', 'b', 'virtual', 100, 'not-json')
+	`, base); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := store.GetNodeStats(ctx, "a", time.Unix(base, 0), time.Unix(base+60, 0))
+	if err == nil || !strings.Contains(err.Error(), "failed to decode node ports") {
+		t.Fatalf("GetNodeStats error = %v, want malformed port error", err)
+	}
+}
+
+func TestGetNodeStatsDoesNotDoubleCountSelfTraffic(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{{
+		Bucket: base, SrcNodeID: "a", DstNodeID: "a", TrafficType: "virtual",
+		TxBytes: 100, RxBytes: 50, FlowCount: 1, Protocols: "[6]", Ports: "[]",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertNodeBandwidth(ctx, []NodeBandwidth{{
+		Bucket: base, NodeID: "a", TxBytes: 100, RxBytes: 50,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := store.GetNodeStats(ctx, "a", time.Unix(base, 0), time.Unix(base+60, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats.TopPeers) != 1 || stats.TopPeers[0].DstNodeID != "a" ||
+		stats.TopPeers[0].TxBytes != 100 || stats.TopPeers[0].RxBytes != 50 ||
+		stats.TopPeers[0].FlowCount != 1 {
+		t.Fatalf("self peer stats = %+v, want one unduplicated peer", stats.TopPeers)
 	}
 }

--- a/backend/internal/database/aggregate_queries_test.go
+++ b/backend/internal/database/aggregate_queries_test.go
@@ -1,0 +1,116 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestAggregateQueriesUseHalfOpenRangesAndMergeMetadata(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{
+		{
+			Bucket: base, SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+			TxBytes: 100, Protocols: "[6]", ProtocolBytes: `{"6":100}`,
+			Ports: `[{"port":443,"proto":6,"bytes":100}]`,
+		},
+		{
+			Bucket: base + 60, SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+			TxBytes: 300, Protocols: "[17]", ProtocolBytes: `{"17":300}`,
+			Ports: `[{"port":53,"proto":17,"bytes":300}]`,
+		},
+		{
+			Bucket: base + 120, SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+			TxBytes: 900, Protocols: "[1]", ProtocolBytes: `{"1":900}`,
+			Ports: `[{"port":7,"proto":1,"bytes":900}]`,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	aggregates, err := store.GetNodePairAggregates(ctx, time.Unix(base, 0), time.Unix(base+120, 0), 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(aggregates) != 1 {
+		t.Fatalf("expected one merged aggregate, got %d", len(aggregates))
+	}
+	if aggregates[0].TxBytes != 400 {
+		t.Fatalf("tx bytes = %d, want 400", aggregates[0].TxBytes)
+	}
+	if aggregates[0].ProtocolBytes != `{"6":100,"17":300}` {
+		t.Fatalf("protocol bytes = %s", aggregates[0].ProtocolBytes)
+	}
+	if aggregates[0].Protocols != "[17,6]" {
+		t.Fatalf("protocol order = %s, want [17,6]", aggregates[0].Protocols)
+	}
+	var ports []PortStat
+	if err := json.Unmarshal([]byte(aggregates[0].Ports), &ports); err != nil {
+		t.Fatal(err)
+	}
+	if len(ports) != 2 || ports[0].Port != 53 || ports[1].Port != 443 {
+		t.Fatalf("ports = %+v", ports)
+	}
+
+	boundary, err := store.GetNodePairAggregates(ctx, time.Unix(base+120, 0), time.Unix(base+180, 0), 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(boundary) != 1 || boundary[0].TxBytes != 900 {
+		t.Fatalf("expected boundary bucket only, got %+v", boundary)
+	}
+}
+
+func TestGetDataRangeSingleBucketReturnsBucketEnd(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{{
+		Bucket: base, SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual", TxBytes: 1, Protocols: "[6]",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	dataRange, err := store.GetDataRange(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dataRange.Earliest.Equal(time.Unix(base, 0).UTC()) || !dataRange.Latest.Equal(time.Unix(base+60, 0).UTC()) {
+		t.Fatalf("data range = %+v", dataRange)
+	}
+}
+
+func TestTrafficStatsUpsertMergesTopPorts(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertTrafficStats(ctx, []TrafficStats{
+		{Bucket: base, TCPBytes: 100, TotalFlows: 1, TopPorts: `[{"port":443,"proto":6,"bytes":100}]`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertTrafficStats(ctx, []TrafficStats{
+		{Bucket: base, UDPBytes: 300, TotalFlows: 2, TopPorts: `[{"port":53,"proto":17,"bytes":300}]`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := store.GetTrafficStats(ctx, time.Unix(base, 0), time.Unix(base+60, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats) != 1 || stats[0].TCPBytes != 100 || stats[0].UDPBytes != 300 || stats[0].TotalFlows != 3 {
+		t.Fatalf("stats = %+v", stats)
+	}
+	var ports []PortStat
+	if err := json.Unmarshal([]byte(stats[0].TopPorts), &ports); err != nil {
+		t.Fatal(err)
+	}
+	if len(ports) != 2 || ports[0].Port != 53 || ports[1].Port != 443 {
+		t.Fatalf("top ports = %+v", ports)
+	}
+}

--- a/backend/internal/database/aggregate_queries_test.go
+++ b/backend/internal/database/aggregate_queries_test.go
@@ -260,3 +260,24 @@ func TestGetNodeStatsDoesNotDoubleCountSelfTraffic(t *testing.T) {
 		t.Fatalf("self peer stats = %+v, want one unduplicated peer", stats.TopPeers)
 	}
 }
+
+func TestGetTopTalkersByTrafficTypesDoesNotDoubleCountSelfTraffic(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	base := (time.Now().UTC().Unix() / 60) * 60
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{{
+		Bucket: base, SrcNodeID: "a", DstNodeID: "a", TrafficType: "virtual",
+		TxBytes: 100, RxBytes: 50, FlowCount: 1, Protocols: "[6]", Ports: "[]",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	talkers, err := store.GetTopTalkersByTrafficTypes(ctx, time.Unix(base, 0), time.Unix(base+60, 0), []string{"virtual"}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(talkers) != 1 || talkers[0].NodeID != "a" ||
+		talkers[0].TxBytes != 100 || talkers[0].RxBytes != 50 || talkers[0].TotalBytes != 150 {
+		t.Fatalf("self talker stats = %+v, want one unduplicated self row", talkers)
+	}
+}

--- a/backend/internal/database/maintenance.go
+++ b/backend/internal/database/maintenance.go
@@ -36,8 +36,13 @@ func (s *SQLiteStore) UpdatePollState(ctx context.Context, lastPollEnd time.Time
 
 	const sqliteFormat = "2006-01-02 15:04:05"
 	_, err := s.db.ExecContext(ctx,
-		"UPDATE poll_state SET last_poll_end = ?, updated_at = CURRENT_TIMESTAMP WHERE id = 1",
-		lastPollEnd.UTC().Format(sqliteFormat),
+		`UPDATE poll_state
+		 SET last_poll_end = CASE
+		       WHEN last_poll_end IS NULL OR last_poll_end = '' OR datetime(last_poll_end) IS NULL OR datetime(last_poll_end) < datetime(?)
+		       THEN ? ELSE last_poll_end END,
+		     updated_at = CURRENT_TIMESTAMP
+		 WHERE id = 1`,
+		lastPollEnd.UTC().Format(sqliteFormat), lastPollEnd.UTC().Format(sqliteFormat),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update poll state: %w", err)
@@ -217,19 +222,27 @@ func (s *SQLiteStore) GetStats(ctx context.Context) (map[string]any, error) {
 	tableCounts := make(map[string]int64)
 	for _, table := range []string{"node_pairs", "bandwidth", "bandwidth_by_node", "traffic_stats", "ingested_objects", "node_metadata"} {
 		var count int64
-		_ = s.db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count)
+		if err := s.db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count); err != nil {
+			return nil, fmt.Errorf("failed to count %s: %w", table, err)
+		}
 		tableCounts[table] = count
 	}
 
 	var pageCount, pageSize int64
-	_ = s.db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount)
-	_ = s.db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&pageSize)
+	if err := s.db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
+		return nil, fmt.Errorf("failed to read database page count: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&pageSize); err != nil {
+		return nil, fmt.Errorf("failed to read database page size: %w", err)
+	}
 
 	var minB, maxB sql.NullInt64
 	var cnt int64
-	_ = s.db.QueryRowContext(ctx,
+	if err := s.db.QueryRowContext(ctx,
 		"SELECT MIN(bucket), MAX(bucket), COUNT(*) FROM node_pairs",
-	).Scan(&minB, &maxB, &cnt)
+	).Scan(&minB, &maxB, &cnt); err != nil {
+		return nil, fmt.Errorf("failed to read database data range: %w", err)
+	}
 	dr := &DataRange{}
 	if cnt > 0 && minB.Valid {
 		dr.Earliest = time.Unix(minB.Int64, 0).UTC()

--- a/backend/internal/database/maintenance.go
+++ b/backend/internal/database/maintenance.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"time"
 )
 
@@ -68,6 +67,75 @@ func (s *SQLiteStore) IsObjectIngested(ctx context.Context, key string) (bool, e
 	return true, nil
 }
 
+// GetObjectsNeedingMetadata returns ingested objects whose embedded node
+// metadata has not been hydrated, or whose previously recorded nodes are
+// missing from node_metadata. The latter makes hydration repair partial
+// metadata-table loss without rescanning the entire object store.
+func (s *SQLiteStore) GetObjectsNeedingMetadata(ctx context.Context, limit int) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if limit <= 0 {
+		return []string{}, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT o.object_key
+		FROM ingested_objects o
+		WHERE o.metadata_hydrated = 0
+		   OR EXISTS (
+				SELECT 1
+				FROM object_metadata_nodes m
+				WHERE m.object_key = o.object_key
+				  AND NOT EXISTS (
+					SELECT 1 FROM node_metadata n WHERE n.node_id = m.node_id
+				  )
+			)
+		ORDER BY o.ingested_at ASC, o.object_key ASC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query objects needing metadata: %w", err)
+	}
+	defer rows.Close()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, fmt.Errorf("failed to scan object needing metadata: %w", err)
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read objects needing metadata: %w", err)
+	}
+	return keys, nil
+}
+
+// MarkObjectMetadataHydrated records the node IDs found while rereading an
+// already-ingested object. It is transactional so a failed metadata upsert
+// never makes the object look complete on the next poll.
+func (s *SQLiteStore) MarkObjectMetadataHydrated(ctx context.Context, key string, nodeIDs []string) error {
+	if key == "" {
+		return fmt.Errorf("object key is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin metadata hydration transaction: %w", err)
+	}
+	defer tx.Rollback()
+	if err := recordObjectMetadataTx(ctx, tx, key, nodeIDs); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit metadata hydration: %w", err)
+	}
+	return nil
+}
+
 func upsertNodeMetadataTx(ctx context.Context, tx *sql.Tx, nodes []NodeMetadata) error {
 	if len(nodes) == 0 {
 		return nil
@@ -103,6 +171,46 @@ func upsertNodeMetadataTx(ctx context.Context, tx *sql.Tx, nodes []NodeMetadata)
 		if _, err := stmt.ExecContext(ctx, node.NodeID, node.Name, node.Hostname, node.Owner, string(ips), string(tags)); err != nil {
 			return fmt.Errorf("failed to upsert node metadata: %w", err)
 		}
+	}
+	return nil
+}
+
+func recordObjectMetadataTx(ctx context.Context, tx *sql.Tx, key string, nodeIDs []string) error {
+	if key == "" {
+		return fmt.Errorf("object key is required")
+	}
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT OR IGNORE INTO object_metadata_nodes (object_key, node_id)
+		VALUES (?, ?)
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare object metadata index: %w", err)
+	}
+	defer stmt.Close()
+
+	seen := make(map[string]struct{}, len(nodeIDs))
+	for _, nodeID := range nodeIDs {
+		if nodeID == "" {
+			continue
+		}
+		if _, ok := seen[nodeID]; ok {
+			continue
+		}
+		seen[nodeID] = struct{}{}
+		if _, err := stmt.ExecContext(ctx, key, nodeID); err != nil {
+			return fmt.Errorf("failed to index metadata for object %q: %w", key, err)
+		}
+	}
+	result, err := tx.ExecContext(ctx,
+		`UPDATE ingested_objects SET metadata_hydrated = 1 WHERE object_key = ?`, key,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to mark object metadata hydrated: %w", err)
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return fmt.Errorf("failed to verify object metadata hydration: %w", err)
+	} else if affected != 1 {
+		return fmt.Errorf("object %q is not recorded as ingested", key)
 	}
 	return nil
 }
@@ -146,8 +254,12 @@ func (s *SQLiteStore) GetNodeMetadata(ctx context.Context) ([]NodeMetadata, erro
 		if err := rows.Scan(&node.NodeID, &node.Name, &node.Hostname, &node.Owner, &ipsJSON, &tagsJSON, &updated); err != nil {
 			return nil, fmt.Errorf("failed to scan node metadata: %w", err)
 		}
-		_ = json.Unmarshal([]byte(ipsJSON), &node.IPs)
-		_ = json.Unmarshal([]byte(tagsJSON), &node.Tags)
+		if err := json.Unmarshal([]byte(ipsJSON), &node.IPs); err != nil {
+			return nil, fmt.Errorf("failed to decode IP metadata for node %q: %w", node.NodeID, err)
+		}
+		if err := json.Unmarshal([]byte(tagsJSON), &node.Tags); err != nil {
+			return nil, fmt.Errorf("failed to decode tag metadata for node %q: %w", node.NodeID, err)
+		}
 		if updated.Valid {
 			node.Updated = parseTime(updated.String)
 		}
@@ -191,25 +303,47 @@ func (s *SQLiteStore) Cleanup(ctx context.Context, retention time.Duration) (int
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin cleanup transaction: %w", err)
+	}
+	defer tx.Rollback()
+
 	cutoff := time.Now().UTC().Unix() - int64(retention.Seconds())
 	var total int64
 	for _, table := range []string{"node_pairs", "bandwidth", "bandwidth_by_node", "traffic_stats"} {
-		result, err := s.db.ExecContext(ctx,
+		result, err := tx.ExecContext(ctx,
 			fmt.Sprintf("DELETE FROM %s WHERE bucket < ?", table), cutoff,
 		)
 		if err != nil {
-			log.Printf("Warning: failed to cleanup %s: %v", table, err)
-			continue
+			return 0, fmt.Errorf("failed to cleanup %s: %w", table, err)
 		}
-		if n, _ := result.RowsAffected(); n > 0 {
+		n, err := result.RowsAffected()
+		if err != nil {
+			return 0, fmt.Errorf("failed to count cleanup rows for %s: %w", table, err)
+		}
+		if n > 0 {
 			total += n
 		}
 	}
-	if _, err := s.db.ExecContext(ctx,
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM object_metadata_nodes
+		 WHERE object_key IN (
+			SELECT object_key FROM ingested_objects
+			WHERE ingested_at < datetime('now', '-' || ? || ' seconds')
+		 )`,
+		int64(retention.Seconds()),
+	); err != nil {
+		return 0, fmt.Errorf("failed to cleanup object metadata index: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
 		"DELETE FROM ingested_objects WHERE ingested_at < datetime('now', '-' || ? || ' seconds')",
 		int64(retention.Seconds()),
 	); err != nil {
-		log.Printf("Warning: failed to cleanup ingested_objects: %v", err)
+		return 0, fmt.Errorf("failed to cleanup ingested_objects: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit cleanup: %w", err)
 	}
 	return total, nil
 }

--- a/backend/internal/database/maintenance.go
+++ b/backend/internal/database/maintenance.go
@@ -169,8 +169,11 @@ func (s *SQLiteStore) GetDataRange(ctx context.Context) (*DataRange, error) {
 	}
 	return &DataRange{
 		Earliest: time.Unix(minBucket.Int64, 0).UTC(),
-		Latest:   time.Unix(maxBucket.Int64, 0).UTC(),
-		Count:    count,
+		// Buckets are minute-start timestamps and all range queries use a
+		// half-open end. Return the end of the newest bucket so a database with
+		// one bucket still describes a usable range.
+		Latest: time.Unix(maxBucket.Int64+60, 0).UTC(),
+		Count:  count,
 	}, nil
 }
 
@@ -230,7 +233,7 @@ func (s *SQLiteStore) GetStats(ctx context.Context) (map[string]any, error) {
 	dr := &DataRange{}
 	if cnt > 0 && minB.Valid {
 		dr.Earliest = time.Unix(minB.Int64, 0).UTC()
-		dr.Latest = time.Unix(maxB.Int64, 0).UTC()
+		dr.Latest = time.Unix(maxB.Int64+60, 0).UTC()
 		dr.Count = cnt
 	}
 

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -18,7 +18,11 @@ type NodePairAggregate struct {
 	RxPkts      int64  `json:"rxPkts"`
 	FlowCount   int64  `json:"flowCount"`
 	Protocols   string `json:"protocols"` // JSON array of protocols seen
-	Ports       string `json:"ports"`     // JSON array of top ports
+	// ProtocolBytes preserves the byte totals needed to identify the dominant
+	// protocol after multiple polls are merged. It is kept internal to the
+	// aggregate response; callers receive the derived Protocol field instead.
+	ProtocolBytes string `json:"-"`
+	Ports         string `json:"ports"` // JSON array of top ports
 }
 
 // BandwidthBucket represents aggregated bandwidth for a time bucket

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -164,7 +164,7 @@ type Store interface {
 
 	// Pre-aggregated data operations
 	UpsertNodePairAggregates(ctx context.Context, aggregates []NodePairAggregate) error
-	GetNodePairAggregates(ctx context.Context, start, end time.Time, bucketSize int64) ([]NodePairAggregate, error)
+	GetNodePairAggregates(ctx context.Context, start, end time.Time) ([]NodePairAggregate, error)
 
 	// Bandwidth operations
 	UpsertBandwidth(ctx context.Context, buckets []BandwidthBucket) error
@@ -188,6 +188,8 @@ type Store interface {
 	CommitPollResults(ctx context.Context, results PollResults) error
 	CommitObjectIngest(ctx context.Context, result ObjectIngestResult) error
 	IsObjectIngested(ctx context.Context, key string) (bool, error)
+	GetObjectsNeedingMetadata(ctx context.Context, limit int) ([]string, error)
+	MarkObjectMetadataHydrated(ctx context.Context, key string, nodeIDs []string) error
 	UpsertNodeMetadata(ctx context.Context, nodes []NodeMetadata) error
 	GetNodeMetadata(ctx context.Context) ([]NodeMetadata, error)
 

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -23,6 +23,18 @@ type NodePairAggregate struct {
 	// aggregate response; callers receive the derived Protocol field instead.
 	ProtocolBytes string `json:"-"`
 	Ports         string `json:"ports"` // JSON array of top ports
+	// TxPorts and RxPorts preserve destination-port observations for each
+	// direction of the normalized pair. They are internal storage fields; the
+	// aggregated-flow handler exposes them only when DirectionalPorts is true.
+	TxPorts         string `json:"-"`
+	RxPorts         string `json:"-"`
+	TxProtocolBytes string `json:"-"`
+	RxProtocolBytes string `json:"-"`
+	// DirectionalPorts indicates that all metadata contributing to this
+	// aggregate has direction-preserving protocol/port information. It is
+	// intentionally false for legacy rows so callers can use the old union
+	// metadata without attributing it to the wrong direction.
+	DirectionalPorts bool `json:"-"`
 }
 
 // BandwidthBucket represents aggregated bandwidth for a time bucket

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -47,6 +47,7 @@ type TrafficStats struct {
 	UDPBytes        int64  `json:"udpBytes"`
 	OtherProtoBytes int64  `json:"otherProtoBytes"`
 	VirtualBytes    int64  `json:"virtualBytes"`
+	ExitBytes       int64  `json:"exitBytes"`
 	SubnetBytes     int64  `json:"subnetBytes"`
 	PhysicalBytes   int64  `json:"physicalBytes"`
 	TotalFlows      int64  `json:"totalFlows"`

--- a/backend/internal/database/schema.go
+++ b/backend/internal/database/schema.go
@@ -84,6 +84,7 @@ func (s *SQLiteStore) Init(ctx context.Context) error {
 		rx_pkts      INTEGER DEFAULT 0,
 		flow_count   INTEGER DEFAULT 0,
 		protocols    TEXT    DEFAULT '[]',
+		protocol_bytes TEXT  DEFAULT '{}',
 		ports        TEXT    DEFAULT '[]',
 		PRIMARY KEY (bucket, src_node_id, dst_node_id, traffic_type)
 	);
@@ -150,7 +151,59 @@ func (s *SQLiteStore) Init(ctx context.Context) error {
 		return fmt.Errorf("failed to create schema: %w", err)
 	}
 
+	// Add columns introduced after the original flat-table migration. SQLite
+	// has no IF NOT EXISTS form for ADD COLUMN, so an already-present column is
+	// intentionally ignored.
+	_, _ = s.db.ExecContext(ctx, `ALTER TABLE node_pairs ADD COLUMN protocol_bytes TEXT DEFAULT '{}'`)
+	if err := s.backfillProtocolBytes(ctx); err != nil {
+		return fmt.Errorf("failed to backfill protocol byte totals: %w", err)
+	}
+
 	log.Printf("Database initialized at %s", s.dbPath)
+	return nil
+}
+
+func (s *SQLiteStore) backfillProtocolBytes(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT rowid, protocols, tx_bytes + rx_bytes, protocol_bytes
+		FROM node_pairs
+		WHERE protocol_bytes IS NULL OR protocol_bytes = '' OR protocol_bytes = '{}'
+	`)
+	if err != nil {
+		return err
+	}
+
+	type row struct {
+		id        int64
+		protocols string
+		total     int64
+	}
+	var pending []row
+	for rows.Next() {
+		var item row
+		var protocolBytes string
+		if err := rows.Scan(&item.id, &item.protocols, &item.total, &protocolBytes); err != nil {
+			rows.Close()
+			return err
+		}
+		pending = append(pending, item)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+
+	for _, item := range pending {
+		protocolBytes := normalizeProtocolBytes("", item.protocols, item.total)
+		if _, err := s.db.ExecContext(ctx,
+			`UPDATE node_pairs SET protocol_bytes = ? WHERE rowid = ?`, protocolBytes, item.id,
+		); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/database/schema.go
+++ b/backend/internal/database/schema.go
@@ -50,14 +50,29 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 // Init creates the database schema
 func (s *SQLiteStore) Init(ctx context.Context) error {
 	// Step 1: Migrate minutely tables to flat names (idempotent).
-	// ALTER TABLE fails if source is absent or target already exists — both are OK.
 	for _, m := range [][2]string{
 		{"node_pairs_minutely", "node_pairs"},
 		{"bandwidth_minutely", "bandwidth"},
 		{"bandwidth_by_node_minutely", "bandwidth_by_node"},
 		{"traffic_stats_minutely", "traffic_stats"},
 	} {
-		_, _ = s.db.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", m[0], m[1]))
+		sourceExists, err := s.tableExists(ctx, m[0])
+		if err != nil {
+			return fmt.Errorf("failed to inspect migration table %s: %w", m[0], err)
+		}
+		if !sourceExists {
+			continue
+		}
+		targetExists, err := s.tableExists(ctx, m[1])
+		if err != nil {
+			return fmt.Errorf("failed to inspect migration table %s: %w", m[1], err)
+		}
+		if targetExists {
+			return fmt.Errorf("cannot migrate %s to %s: both tables exist", m[0], m[1])
+		}
+		if _, err := s.db.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", m[0], m[1])); err != nil {
+			return fmt.Errorf("failed to migrate %s to %s: %w", m[0], m[1], err)
+		}
 	}
 
 	// Step 2: Drop old tier tables and the ephemeral raw-log table.
@@ -68,7 +83,9 @@ func (s *SQLiteStore) Init(ctx context.Context) error {
 		"traffic_stats_hourly", "traffic_stats_daily",
 		"flow_logs_current",
 	} {
-		_, _ = s.db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+		if _, err := s.db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", table)); err != nil {
+			return fmt.Errorf("failed to drop obsolete table %s: %w", table, err)
+		}
 	}
 
 	// Step 3: Create flat tables (IF NOT EXISTS handles fresh installs and post-migration runs).
@@ -152,9 +169,17 @@ func (s *SQLiteStore) Init(ctx context.Context) error {
 	}
 
 	// Add columns introduced after the original flat-table migration. SQLite
-	// has no IF NOT EXISTS form for ADD COLUMN, so an already-present column is
-	// intentionally ignored.
-	_, _ = s.db.ExecContext(ctx, `ALTER TABLE node_pairs ADD COLUMN protocol_bytes TEXT DEFAULT '{}'`)
+	// has no IF NOT EXISTS form for ADD COLUMN, so inspect the schema before
+	// executing the migration and surface real ALTER TABLE failures.
+	protocolBytesExists, err := s.columnExists(ctx, "node_pairs", "protocol_bytes")
+	if err != nil {
+		return fmt.Errorf("failed to inspect node_pairs columns: %w", err)
+	}
+	if !protocolBytesExists {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE node_pairs ADD COLUMN protocol_bytes TEXT DEFAULT '{}'`); err != nil {
+			return fmt.Errorf("failed to add node_pairs.protocol_bytes: %w", err)
+		}
+	}
 	if err := s.backfillProtocolBytes(ctx); err != nil {
 		return fmt.Errorf("failed to backfill protocol byte totals: %w", err)
 	}
@@ -168,6 +193,7 @@ func (s *SQLiteStore) backfillProtocolBytes(ctx context.Context) error {
 		SELECT rowid, protocols, tx_bytes + rx_bytes, protocol_bytes
 		FROM node_pairs
 		WHERE protocol_bytes IS NULL OR protocol_bytes = '' OR protocol_bytes = '{}'
+		   OR NOT json_valid(protocol_bytes)
 	`)
 	if err != nil {
 		return err
@@ -205,6 +231,36 @@ func (s *SQLiteStore) backfillProtocolBytes(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (s *SQLiteStore) tableExists(ctx context.Context, table string) (bool, error) {
+	var exists int
+	err := s.db.QueryRowContext(ctx,
+		"SELECT EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?)", table,
+	).Scan(&exists)
+	return exists != 0, err
+}
+
+func (s *SQLiteStore) columnExists(ctx context.Context, table, column string) (bool, error) {
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name, columnType string
+		var notNull, primaryKey int
+		var defaultValue sql.NullString
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 // Close closes the database connection

--- a/backend/internal/database/schema.go
+++ b/backend/internal/database/schema.go
@@ -130,6 +130,7 @@ func (s *SQLiteStore) Init(ctx context.Context) error {
 		udp_bytes         INTEGER DEFAULT 0,
 		other_proto_bytes INTEGER DEFAULT 0,
 		virtual_bytes     INTEGER DEFAULT 0,
+		exit_bytes        INTEGER DEFAULT 0,
 		subnet_bytes      INTEGER DEFAULT 0,
 		physical_bytes    INTEGER DEFAULT 0,
 		total_flows       INTEGER DEFAULT 0,
@@ -197,6 +198,15 @@ func (s *SQLiteStore) Init(ctx context.Context) error {
 		// index existed, so schedule them for bounded hydration on upgrade.
 		if _, err := s.db.ExecContext(ctx, `ALTER TABLE ingested_objects ADD COLUMN metadata_hydrated INTEGER NOT NULL DEFAULT 0`); err != nil {
 			return fmt.Errorf("failed to add ingested_objects.metadata_hydrated: %w", err)
+		}
+	}
+	exitBytesExists, err := s.columnExists(ctx, "traffic_stats", "exit_bytes")
+	if err != nil {
+		return fmt.Errorf("failed to inspect traffic_stats columns: %w", err)
+	}
+	if !exitBytesExists {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE traffic_stats ADD COLUMN exit_bytes INTEGER DEFAULT 0`); err != nil {
+			return fmt.Errorf("failed to add traffic_stats.exit_bytes: %w", err)
 		}
 	}
 	if err := s.backfillProtocolBytes(ctx); err != nil {

--- a/backend/internal/database/schema.go
+++ b/backend/internal/database/schema.go
@@ -145,11 +145,12 @@ func (s *SQLiteStore) Init(ctx context.Context) error {
 	INSERT OR IGNORE INTO poll_state (id, last_poll_end, updated_at) VALUES (1, NULL, CURRENT_TIMESTAMP);
 
 	CREATE TABLE IF NOT EXISTS ingested_objects (
-		object_key    TEXT PRIMARY KEY,
-		last_modified DATETIME,
-		size_bytes    INTEGER DEFAULT 0,
-		flow_count    INTEGER DEFAULT 0,
-		ingested_at   DATETIME DEFAULT CURRENT_TIMESTAMP
+		object_key          TEXT PRIMARY KEY,
+		last_modified       DATETIME,
+		size_bytes          INTEGER DEFAULT 0,
+		flow_count          INTEGER DEFAULT 0,
+		ingested_at         DATETIME DEFAULT CURRENT_TIMESTAMP,
+		metadata_hydrated   INTEGER NOT NULL DEFAULT 0
 	);
 	CREATE INDEX IF NOT EXISTS idx_ingested_objects_ingested_at ON ingested_objects(ingested_at);
 
@@ -162,6 +163,13 @@ func (s *SQLiteStore) Init(ctx context.Context) error {
 		tags       TEXT DEFAULT '[]',
 		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	);
+
+	CREATE TABLE IF NOT EXISTS object_metadata_nodes (
+		object_key TEXT NOT NULL,
+		node_id    TEXT NOT NULL,
+		PRIMARY KEY (object_key, node_id)
+	);
+	CREATE INDEX IF NOT EXISTS idx_object_metadata_nodes_node ON object_metadata_nodes(node_id);
 	`
 
 	if _, err := s.db.ExecContext(ctx, schema); err != nil {
@@ -178,6 +186,17 @@ func (s *SQLiteStore) Init(ctx context.Context) error {
 	if !protocolBytesExists {
 		if _, err := s.db.ExecContext(ctx, `ALTER TABLE node_pairs ADD COLUMN protocol_bytes TEXT DEFAULT '{}'`); err != nil {
 			return fmt.Errorf("failed to add node_pairs.protocol_bytes: %w", err)
+		}
+	}
+	metadataHydratedExists, err := s.columnExists(ctx, "ingested_objects", "metadata_hydrated")
+	if err != nil {
+		return fmt.Errorf("failed to inspect ingested_objects columns: %w", err)
+	}
+	if !metadataHydratedExists {
+		// Existing ingestion rows were written before the per-object metadata
+		// index existed, so schedule them for bounded hydration on upgrade.
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE ingested_objects ADD COLUMN metadata_hydrated INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("failed to add ingested_objects.metadata_hydrated: %w", err)
 		}
 	}
 	if err := s.backfillProtocolBytes(ctx); err != nil {

--- a/backend/internal/database/schema.go
+++ b/backend/internal/database/schema.go
@@ -103,6 +103,11 @@ func (s *SQLiteStore) Init(ctx context.Context) error {
 		protocols    TEXT    DEFAULT '[]',
 		protocol_bytes TEXT  DEFAULT '{}',
 		ports        TEXT    DEFAULT '[]',
+		tx_ports     TEXT    DEFAULT '[]',
+		rx_ports     TEXT    DEFAULT '[]',
+		tx_protocol_bytes TEXT DEFAULT '{}',
+		rx_protocol_bytes TEXT DEFAULT '{}',
+		directional_ports INTEGER NOT NULL DEFAULT 0,
 		PRIMARY KEY (bucket, src_node_id, dst_node_id, traffic_type)
 	);
 	CREATE INDEX IF NOT EXISTS idx_node_pairs_bucket ON node_pairs(bucket);
@@ -187,6 +192,26 @@ func (s *SQLiteStore) Init(ctx context.Context) error {
 	if !protocolBytesExists {
 		if _, err := s.db.ExecContext(ctx, `ALTER TABLE node_pairs ADD COLUMN protocol_bytes TEXT DEFAULT '{}'`); err != nil {
 			return fmt.Errorf("failed to add node_pairs.protocol_bytes: %w", err)
+		}
+	}
+	for _, column := range []struct {
+		name string
+		ddl  string
+	}{
+		{name: "tx_ports", ddl: `ALTER TABLE node_pairs ADD COLUMN tx_ports TEXT DEFAULT '[]'`},
+		{name: "rx_ports", ddl: `ALTER TABLE node_pairs ADD COLUMN rx_ports TEXT DEFAULT '[]'`},
+		{name: "tx_protocol_bytes", ddl: `ALTER TABLE node_pairs ADD COLUMN tx_protocol_bytes TEXT DEFAULT '{}'`},
+		{name: "rx_protocol_bytes", ddl: `ALTER TABLE node_pairs ADD COLUMN rx_protocol_bytes TEXT DEFAULT '{}'`},
+		{name: "directional_ports", ddl: `ALTER TABLE node_pairs ADD COLUMN directional_ports INTEGER NOT NULL DEFAULT 0`},
+	} {
+		exists, err := s.columnExists(ctx, "node_pairs", column.name)
+		if err != nil {
+			return fmt.Errorf("failed to inspect node_pairs.%s: %w", column.name, err)
+		}
+		if !exists {
+			if _, err := s.db.ExecContext(ctx, column.ddl); err != nil {
+				return fmt.Errorf("failed to add node_pairs.%s: %w", column.name, err)
+			}
 		}
 	}
 	metadataHydratedExists, err := s.columnExists(ctx, "ingested_objects", "metadata_hydrated")

--- a/backend/internal/database/schema_test.go
+++ b/backend/internal/database/schema_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -203,6 +204,268 @@ func TestInit_Migration(t *testing.T) {
 		).Scan(&name)
 		if err == nil {
 			t.Errorf("old table %q still exists after migration", table)
+		}
+	}
+}
+
+func TestInit_Migration_LegacyFlatTables(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	store, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	const oldSchema = `
+		CREATE TABLE node_pairs (
+			bucket INTEGER NOT NULL,
+			src_node_id TEXT NOT NULL,
+			dst_node_id TEXT NOT NULL,
+			traffic_type TEXT NOT NULL,
+			tx_bytes INTEGER DEFAULT 0,
+			rx_bytes INTEGER DEFAULT 0,
+			tx_pkts INTEGER DEFAULT 0,
+			rx_pkts INTEGER DEFAULT 0,
+			flow_count INTEGER DEFAULT 0,
+			protocols TEXT DEFAULT '[]',
+			ports TEXT DEFAULT '[]',
+			PRIMARY KEY (bucket, src_node_id, dst_node_id, traffic_type)
+		);
+		INSERT INTO node_pairs
+			(bucket, src_node_id, dst_node_id, traffic_type, tx_bytes, rx_bytes,
+			 tx_pkts, rx_pkts, flow_count, protocols, ports)
+		VALUES (120, 'legacy-a', 'legacy-b', 'virtual', 100, 50, 2, 1, 1, '[6,17]', '[]');
+
+		CREATE TABLE traffic_stats (
+			bucket INTEGER PRIMARY KEY,
+			tcp_bytes INTEGER DEFAULT 0,
+			udp_bytes INTEGER DEFAULT 0,
+			other_proto_bytes INTEGER DEFAULT 0,
+			virtual_bytes INTEGER DEFAULT 0,
+			subnet_bytes INTEGER DEFAULT 0,
+			physical_bytes INTEGER DEFAULT 0,
+			total_flows INTEGER DEFAULT 0,
+			unique_pairs INTEGER DEFAULT 0,
+			top_ports TEXT DEFAULT '[]'
+		);
+		INSERT INTO traffic_stats
+			(bucket, tcp_bytes, virtual_bytes, total_flows, unique_pairs, top_ports)
+		VALUES (120, 10, 10, 1, 1, '[]');
+
+		CREATE TABLE ingested_objects (
+			object_key TEXT PRIMARY KEY,
+			last_modified DATETIME,
+			size_bytes INTEGER DEFAULT 0,
+			flow_count INTEGER DEFAULT 0,
+			ingested_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+		INSERT INTO ingested_objects (object_key, last_modified, size_bytes, flow_count)
+		VALUES ('legacy-object.ndjson', '2026-08-13 00:00:00', 42, 1);
+	`
+	if _, err := store.db.ExecContext(ctx, oldSchema); err != nil {
+		t.Fatalf("failed to create legacy schema: %v", err)
+	}
+
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	for _, column := range []string{
+		"protocol_bytes", "tx_ports", "rx_ports", "tx_protocol_bytes",
+		"rx_protocol_bytes", "directional_ports",
+	} {
+		exists, err := store.columnExists(ctx, "node_pairs", column)
+		if err != nil {
+			t.Fatalf("failed to inspect node_pairs.%s: %v", column, err)
+		}
+		if !exists {
+			t.Errorf("node_pairs.%s was not added during migration", column)
+		}
+	}
+
+	pairs, err := store.GetNodePairAggregates(ctx, time.Unix(0, 0).UTC(), time.Unix(600, 0).UTC())
+	if err != nil {
+		t.Fatalf("querying migrated node pairs failed: %v", err)
+	}
+	if len(pairs) != 1 {
+		t.Fatalf("expected one migrated node pair, got %d", len(pairs))
+	}
+	if pairs[0].TxBytes != 100 || pairs[0].RxBytes != 50 || pairs[0].FlowCount != 1 {
+		t.Fatalf("unexpected migrated node pair: %+v", pairs[0])
+	}
+	if pairs[0].DirectionalPorts {
+		t.Fatal("legacy node pair should not be marked as directional")
+	}
+	assertProtocolByteMap(t, pairs[0].ProtocolBytes, map[string]int64{"6": 75, "17": 75})
+
+	if err := store.UpsertNodePairAggregates(ctx, []NodePairAggregate{{
+		Bucket:        120,
+		SrcNodeID:     "legacy-a",
+		DstNodeID:     "legacy-b",
+		TrafficType:   "virtual",
+		TxBytes:       20,
+		RxBytes:       5,
+		TxPkts:        1,
+		RxPkts:        1,
+		FlowCount:     1,
+		Protocols:     "[6]",
+		ProtocolBytes: `{"6":25}`,
+		Ports:         "[]",
+	}}); err != nil {
+		t.Fatalf("upserting into migrated node_pairs failed: %v", err)
+	}
+
+	pairs, err = store.GetNodePairAggregates(ctx, time.Unix(0, 0).UTC(), time.Unix(600, 0).UTC())
+	if err != nil {
+		t.Fatalf("querying upserted node pair failed: %v", err)
+	}
+	if len(pairs) != 1 {
+		t.Fatalf("expected one upserted node pair, got %d", len(pairs))
+	}
+	if pairs[0].TxBytes != 120 || pairs[0].RxBytes != 55 || pairs[0].FlowCount != 2 {
+		t.Fatalf("unexpected upserted node pair: %+v", pairs[0])
+	}
+	assertProtocolByteMap(t, pairs[0].ProtocolBytes, map[string]int64{"6": 100, "17": 75})
+
+	stats, err := store.GetTrafficStats(ctx, time.Unix(0, 0).UTC(), time.Unix(600, 0).UTC())
+	if err != nil {
+		t.Fatalf("querying migrated traffic stats failed: %v", err)
+	}
+	if len(stats) != 1 || stats[0].TCPBytes != 10 || stats[0].ExitBytes != 0 {
+		t.Fatalf("unexpected migrated traffic stats: %+v", stats)
+	}
+	if err := store.UpsertTrafficStats(ctx, []TrafficStats{{
+		Bucket:      120,
+		TCPBytes:    5,
+		ExitBytes:   7,
+		TotalFlows:  1,
+		UniquePairs: 1,
+		TopPorts:    "[]",
+	}}); err != nil {
+		t.Fatalf("upserting into migrated traffic_stats failed: %v", err)
+	}
+	stats, err = store.GetTrafficStats(ctx, time.Unix(0, 0).UTC(), time.Unix(600, 0).UTC())
+	if err != nil {
+		t.Fatalf("querying upserted traffic stats failed: %v", err)
+	}
+	if len(stats) != 1 || stats[0].TCPBytes != 15 || stats[0].ExitBytes != 7 {
+		t.Fatalf("unexpected upserted traffic stats: %+v", stats)
+	}
+
+	keys, err := store.GetObjectsNeedingMetadata(ctx, 10)
+	if err != nil {
+		t.Fatalf("querying migrated ingested objects failed: %v", err)
+	}
+	if len(keys) != 1 || keys[0] != "legacy-object.ndjson" {
+		t.Fatalf("migrated object metadata queue = %v", keys)
+	}
+	if err := store.UpsertNodeMetadata(ctx, []NodeMetadata{{NodeID: "legacy-a"}}); err != nil {
+		t.Fatalf("seeding migrated object node metadata failed: %v", err)
+	}
+	if err := store.MarkObjectMetadataHydrated(ctx, keys[0], []string{"legacy-a"}); err != nil {
+		t.Fatalf("marking migrated object metadata hydrated failed: %v", err)
+	}
+	keys, err = store.GetObjectsNeedingMetadata(ctx, 10)
+	if err != nil {
+		t.Fatalf("querying hydrated ingested objects failed: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("hydrated migrated objects still queued: %v", keys)
+	}
+}
+
+func TestInit_Migration_MalformedProtocolJSON(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	store, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	const oldSchema = `
+		CREATE TABLE node_pairs (
+			bucket INTEGER NOT NULL,
+			src_node_id TEXT NOT NULL,
+			dst_node_id TEXT NOT NULL,
+			traffic_type TEXT NOT NULL,
+			tx_bytes INTEGER DEFAULT 0,
+			rx_bytes INTEGER DEFAULT 0,
+			tx_pkts INTEGER DEFAULT 0,
+			rx_pkts INTEGER DEFAULT 0,
+			flow_count INTEGER DEFAULT 0,
+			protocols TEXT DEFAULT '[]',
+			protocol_bytes TEXT DEFAULT '{}',
+			ports TEXT DEFAULT '[]',
+			PRIMARY KEY (bucket, src_node_id, dst_node_id, traffic_type)
+		);
+		INSERT INTO node_pairs
+			(bucket, src_node_id, dst_node_id, traffic_type, tx_bytes, rx_bytes,
+			 flow_count, protocols, protocol_bytes, ports)
+		VALUES (120, 'valid-protocols', 'peer', 'virtual', 90, 30, 1, '[6,17]', '{broken', '[]');
+		INSERT INTO node_pairs
+			(bucket, src_node_id, dst_node_id, traffic_type, tx_bytes, rx_bytes,
+			 flow_count, protocols, protocol_bytes, ports)
+		VALUES (180, 'invalid-protocols', 'peer', 'virtual', 10, 2, 1, '[6', 'not-json', '[]');
+	`
+	if _, err := store.db.ExecContext(ctx, oldSchema); err != nil {
+		t.Fatalf("failed to create legacy schema: %v", err)
+	}
+
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("Init failed for malformed protocol JSON: %v", err)
+	}
+
+	var validRaw, invalidRaw string
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT protocol_bytes FROM node_pairs WHERE src_node_id = ?", "valid-protocols",
+	).Scan(&validRaw); err != nil {
+		t.Fatalf("failed to read repaired protocol bytes: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT protocol_bytes FROM node_pairs WHERE src_node_id = ?", "invalid-protocols",
+	).Scan(&invalidRaw); err != nil {
+		t.Fatalf("failed to read repaired invalid protocol bytes: %v", err)
+	}
+	assertProtocolByteMap(t, validRaw, map[string]int64{"6": 60, "17": 60})
+	assertProtocolByteMap(t, invalidRaw, map[string]int64{})
+
+	pairs, err := store.GetNodePairAggregates(ctx, time.Unix(0, 0).UTC(), time.Unix(600, 0).UTC())
+	if err != nil {
+		t.Fatalf("querying rows with malformed protocol JSON failed: %v", err)
+	}
+	if len(pairs) != 2 {
+		t.Fatalf("expected two migrated node pairs, got %d", len(pairs))
+	}
+	for _, pair := range pairs {
+		switch pair.SrcNodeID {
+		case "valid-protocols":
+			assertProtocolByteMap(t, pair.ProtocolBytes, map[string]int64{"6": 60, "17": 60})
+		case "invalid-protocols":
+			assertProtocolByteMap(t, pair.ProtocolBytes, map[string]int64{})
+		default:
+			t.Errorf("unexpected migrated node pair: %+v", pair)
+		}
+	}
+}
+
+func assertProtocolByteMap(t *testing.T, raw string, want map[string]int64) {
+	t.Helper()
+	var got map[string]int64
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("invalid protocol byte JSON %q: %v", raw, err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("protocol byte map = %v, want %v", got, want)
+	}
+	for protocol, wantBytes := range want {
+		if got[protocol] != wantBytes {
+			t.Errorf("protocol %s bytes = %d, want %d", protocol, got[protocol], wantBytes)
 		}
 	}
 }

--- a/backend/internal/database/schema_test.go
+++ b/backend/internal/database/schema_test.go
@@ -57,6 +57,38 @@ func TestPollState(t *testing.T) {
 	}
 }
 
+func TestPollStateDoesNotMoveBackward(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	future := time.Date(2026, 5, 8, 13, 45, 0, 0, time.UTC)
+	past := future.Add(-time.Hour)
+
+	if err := store.UpdatePollState(ctx, future); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdatePollState(ctx, past); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := store.GetPollState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.LastPollEnd.Equal(future) {
+		t.Fatalf("poll cursor = %v, want %v", state.LastPollEnd, future)
+	}
+}
+
+func TestGetStatsReturnsDatabaseErrors(t *testing.T) {
+	store := setupTestDB(t)
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GetStats(context.Background()); err == nil {
+		t.Fatal("expected GetStats to return an error for a closed database")
+	}
+}
+
 func TestGetDataRange_Empty(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()

--- a/backend/internal/database/schema_test.go
+++ b/backend/internal/database/schema_test.go
@@ -187,6 +187,13 @@ func TestInit_Migration(t *testing.T) {
 	if count != 1 {
 		t.Errorf("expected 1 row in node_pairs after migration, got %d", count)
 	}
+	var exitColumn int
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('traffic_stats') WHERE name = 'exit_bytes'").Scan(&exitColumn); err != nil {
+		t.Fatalf("failed to inspect migrated traffic_stats schema: %v", err)
+	}
+	if exitColumn != 1 {
+		t.Fatal("traffic_stats.exit_bytes was not added during migration")
+	}
 
 	// Verify old tables were dropped
 	for _, table := range []string{"node_pairs_minutely", "node_pairs_hourly", "node_pairs_daily", "flow_logs_current"} {

--- a/backend/internal/database/schema_test.go
+++ b/backend/internal/database/schema_test.go
@@ -292,7 +292,7 @@ func TestCommitObjectIngest_Idempotent(t *testing.T) {
 		t.Fatal("expected object to be marked ingested")
 	}
 
-	pairs, err := store.GetNodePairAggregates(ctx, pollEnd.Add(-time.Minute), pollEnd.Add(time.Minute), 60)
+	pairs, err := store.GetNodePairAggregates(ctx, pollEnd.Add(-time.Minute), pollEnd.Add(time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,6 +315,49 @@ func TestCommitObjectIngest_Idempotent(t *testing.T) {
 	}
 	if len(nodes[0].IPs) != 1 || nodes[0].IPs[0] != "100.64.1.2" {
 		t.Fatalf("unexpected node metadata IPs: %+v", nodes[0].IPs)
+	}
+}
+
+func TestObjectMetadataHydrationStateRepairsMissingNodes(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	result := ObjectIngestResult{
+		Key:          "network/test.ndjson",
+		NodeMetadata: []NodeMetadata{{NodeID: "node-a"}, {NodeID: "node-b"}},
+		PollEnd:      time.Unix(60, 0).UTC(),
+	}
+	if err := store.CommitObjectIngest(ctx, result); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := store.GetObjectsNeedingMetadata(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("newly ingested object needs metadata hydration: %v", keys)
+	}
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM node_metadata WHERE node_id = ?", "node-b"); err != nil {
+		t.Fatal(err)
+	}
+	keys, err = store.GetObjectsNeedingMetadata(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 1 || keys[0] != result.Key {
+		t.Fatalf("objects needing repair = %v, want %q", keys, result.Key)
+	}
+	if err := store.UpsertNodeMetadata(ctx, []NodeMetadata{{NodeID: "node-b"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkObjectMetadataHydrated(ctx, result.Key, []string{"node-a", "node-b"}); err != nil {
+		t.Fatal(err)
+	}
+	keys, err = store.GetObjectsNeedingMetadata(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("repaired object still needs metadata: %v", keys)
 	}
 }
 

--- a/backend/internal/handlers/bandwidth_handlers.go
+++ b/backend/internal/handlers/bandwidth_handlers.go
@@ -55,7 +55,11 @@ func (h *Handlers) GetBandwidthAggregated(c *gin.Context) {
 	// Try rolling cache first for recent data (within last hour)
 	if h.poller != nil && len(trafficTypes) == 0 {
 		cache := h.poller.GetRollingCache()
-		if cache.HasDataFor(startTime, endTime) {
+		cacheHasData := cache.HasBandwidthDataFor(startTime, endTime)
+		if nodeID != "" {
+			cacheHasData = cache.HasNodeBandwidthDataFor(startTime, endTime, nodeID)
+		}
+		if cacheHasData {
 			if nodeID != "" {
 				buckets = cache.GetNodeBandwidth(startTime, endTime, nodeID)
 			} else {

--- a/backend/internal/handlers/bandwidth_handlers.go
+++ b/backend/internal/handlers/bandwidth_handlers.go
@@ -231,7 +231,19 @@ func (h *Handlers) GetBandwidthByIPs(c *gin.Context) {
 	for nodeID := range nodeIDs {
 		buckets, err := h.store.GetNodeBandwidth(ctx, startTime, endTime, nodeID)
 		if err != nil {
-			continue // Skip errors for individual nodes
+			if errors.Is(err, context.Canceled) || errors.Is(c.Request.Context().Err(), context.Canceled) {
+				c.Status(499)
+				return
+			}
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(c.Request.Context().Err(), context.DeadlineExceeded) {
+				c.Status(http.StatusGatewayTimeout)
+				return
+			}
+			log.Printf("ERROR GetBandwidthByIPs for node %q: %v", nodeID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to fetch bandwidth data",
+			})
+			return
 		}
 		for _, b := range buckets {
 			bucket := b.Time.Unix()

--- a/backend/internal/handlers/bandwidth_handlers.go
+++ b/backend/internal/handlers/bandwidth_handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"math"
 	"net"
@@ -31,7 +32,11 @@ func (h *Handlers) GetBandwidthAggregated(c *gin.Context) {
 	}
 
 	nodeID := c.Query("nodeId")
-	trafficTypes := parseBandwidthTrafficTypes(c.Query("trafficTypes"))
+	trafficTypes, trafficTypesErr := parseBandwidthTrafficTypes(c.Query("trafficTypes"))
+	if trafficTypesErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": trafficTypesErr.Error()})
+		return
+	}
 	// Validate nodeId if provided — must be non-empty after trimming
 	if c.Query("nodeId") != "" && strings.TrimSpace(nodeID) == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "nodeId must be non-empty if provided"})
@@ -142,9 +147,9 @@ func (h *Handlers) GetBandwidthAggregated(c *gin.Context) {
 	})
 }
 
-func parseBandwidthTrafficTypes(raw string) []string {
+func parseBandwidthTrafficTypes(raw string) ([]string, error) {
 	if raw == "" {
-		return nil
+		return nil, nil
 	}
 	allowed := map[string]bool{
 		"virtual":  true,
@@ -156,13 +161,16 @@ func parseBandwidthTrafficTypes(raw string) []string {
 	var result []string
 	for _, value := range strings.Split(raw, ",") {
 		value = strings.TrimSpace(value)
-		if !allowed[value] || seen[value] {
+		if value == "" || !allowed[value] {
+			return nil, fmt.Errorf("trafficTypes contains invalid value %q", value)
+		}
+		if seen[value] {
 			continue
 		}
 		seen[value] = true
 		result = append(result, value)
 	}
-	return result
+	return result, nil
 }
 
 // GetBandwidthByIPs returns bandwidth data filtered by IP addresses
@@ -194,6 +202,10 @@ func (h *Handlers) GetBandwidthByIPs(c *gin.Context) {
 	ips := strings.Split(ipsStr, ",")
 	for i := range ips {
 		ips[i] = strings.TrimSpace(ips[i])
+		if ips[i] == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "ips must not contain empty entries"})
+			return
+		}
 	}
 
 	// Use poller's device cache to resolve IPs to node IDs

--- a/backend/internal/handlers/bandwidth_handlers.go
+++ b/backend/internal/handlers/bandwidth_handlers.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"log"
 	"math"
 	"net"
@@ -83,8 +82,7 @@ func (h *Handlers) GetBandwidthAggregated(c *gin.Context) {
 		}
 
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(c.Request.Context().Err(), context.Canceled) {
-				c.Status(499)
+			if writeContextError(c, err) {
 				return
 			}
 			log.Printf("ERROR GetBandwidthAggregated: %v", err)
@@ -126,15 +124,7 @@ func (h *Handlers) GetBandwidthAggregated(c *gin.Context) {
 			bucketSeconds = 60
 		}
 	} else {
-		// Fallback heuristic for 0-1 data points
-		rangeSeconds := int64(endTime.Sub(startTime).Seconds())
-		if rangeSeconds <= 24*3600 {
-			bucketSeconds = 60
-		} else if rangeSeconds <= 7*24*3600 {
-			bucketSeconds = 3600
-		} else {
-			bucketSeconds = 86400
-		}
+		bucketSeconds = bucketSizeForRange(startTime, endTime)
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -231,12 +221,7 @@ func (h *Handlers) GetBandwidthByIPs(c *gin.Context) {
 	for nodeID := range nodeIDs {
 		buckets, err := h.store.GetNodeBandwidth(ctx, startTime, endTime, nodeID)
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(c.Request.Context().Err(), context.Canceled) {
-				c.Status(499)
-				return
-			}
-			if errors.Is(err, context.DeadlineExceeded) || errors.Is(c.Request.Context().Err(), context.DeadlineExceeded) {
-				c.Status(http.StatusGatewayTimeout)
+			if writeContextError(c, err) {
 				return
 			}
 			log.Printf("ERROR GetBandwidthByIPs for node %q: %v", nodeID, err)
@@ -284,14 +269,7 @@ func (h *Handlers) GetBandwidthByIPs(c *gin.Context) {
 			bucketSeconds = 60
 		}
 	} else {
-		rangeSeconds := int64(endTime.Sub(startTime).Seconds())
-		if rangeSeconds <= 24*3600 {
-			bucketSeconds = 60
-		} else if rangeSeconds <= 7*24*3600 {
-			bucketSeconds = 3600
-		} else {
-			bucketSeconds = 86400
-		}
+		bucketSeconds = bucketSizeForRange(startTime, endTime)
 	}
 
 	if allBuckets == nil {

--- a/backend/internal/handlers/device_handlers.go
+++ b/backend/internal/handlers/device_handlers.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"context"
-	"errors"
 	"log"
 	"net/http"
 
@@ -34,26 +32,14 @@ func (h *Handlers) GetDevices(c *gin.Context) {
 
 func (h *Handlers) GetServicesAndRecords(c *gin.Context) {
 	ctx := c.Request.Context()
-	if err := ctx.Err(); err != nil {
-		if errors.Is(err, context.Canceled) {
-			c.Status(499)
-			return
-		}
-		if errors.Is(err, context.DeadlineExceeded) {
-			c.Status(http.StatusGatewayTimeout)
-			return
-		}
+	if err := ctx.Err(); err != nil && writeContextError(c, err) {
+		return
 	}
 
 	// Fetch VIP services
 	vipServices, servicesErr := h.tailscaleService.GetVIPServices(ctx)
 	if servicesErr != nil {
-		if errors.Is(servicesErr, context.Canceled) {
-			c.Status(499)
-			return
-		}
-		if errors.Is(servicesErr, context.DeadlineExceeded) {
-			c.Status(http.StatusGatewayTimeout)
+		if writeContextError(c, servicesErr) {
 			return
 		}
 		log.Printf("WARNING GetVIPServices failed: %v", servicesErr)
@@ -63,12 +49,7 @@ func (h *Handlers) GetServicesAndRecords(c *gin.Context) {
 	// Fetch static records
 	staticRecords, recordsErr := h.tailscaleService.GetStaticRecords(ctx)
 	if recordsErr != nil {
-		if errors.Is(recordsErr, context.Canceled) {
-			c.Status(499)
-			return
-		}
-		if errors.Is(recordsErr, context.DeadlineExceeded) {
-			c.Status(http.StatusGatewayTimeout)
+		if writeContextError(c, recordsErr) {
 			return
 		}
 		log.Printf("WARNING GetStaticRecords failed: %v", recordsErr)

--- a/backend/internal/handlers/device_handlers.go
+++ b/backend/internal/handlers/device_handlers.go
@@ -17,7 +17,7 @@ func (h *Handlers) GetDevices(c *gin.Context) {
 		}
 	}
 
-	devices, err := h.tailscaleService.GetDevices()
+	devices, err := h.tailscaleService.GetDevicesWithContext(c.Request.Context())
 	if err != nil {
 		log.Printf("ERROR GetDevices: %v", err)
 		c.JSON(http.StatusOK, gin.H{"devices": []services.Device{}})

--- a/backend/internal/handlers/device_handlers.go
+++ b/backend/internal/handlers/device_handlers.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"log"
 	"net/http"
 
@@ -29,10 +31,28 @@ func (h *Handlers) GetDevices(c *gin.Context) {
 
 func (h *Handlers) GetServicesAndRecords(c *gin.Context) {
 	ctx := c.Request.Context()
+	if err := ctx.Err(); err != nil {
+		if errors.Is(err, context.Canceled) {
+			c.Status(499)
+			return
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			c.Status(http.StatusGatewayTimeout)
+			return
+		}
+	}
 
 	// Fetch VIP services
 	vipServices, servicesErr := h.tailscaleService.GetVIPServices(ctx)
 	if servicesErr != nil {
+		if errors.Is(servicesErr, context.Canceled) {
+			c.Status(499)
+			return
+		}
+		if errors.Is(servicesErr, context.DeadlineExceeded) {
+			c.Status(http.StatusGatewayTimeout)
+			return
+		}
 		log.Printf("WARNING GetVIPServices failed: %v", servicesErr)
 		vipServices = make(map[string]services.VIPServiceInfo)
 	}
@@ -40,6 +60,14 @@ func (h *Handlers) GetServicesAndRecords(c *gin.Context) {
 	// Fetch static records
 	staticRecords, recordsErr := h.tailscaleService.GetStaticRecords(ctx)
 	if recordsErr != nil {
+		if errors.Is(recordsErr, context.Canceled) {
+			c.Status(499)
+			return
+		}
+		if errors.Is(recordsErr, context.DeadlineExceeded) {
+			c.Status(http.StatusGatewayTimeout)
+			return
+		}
 		log.Printf("WARNING GetStaticRecords failed: %v", recordsErr)
 		staticRecords = make(map[string]services.StaticRecordInfo)
 	}

--- a/backend/internal/handlers/device_handlers.go
+++ b/backend/internal/handlers/device_handlers.go
@@ -21,6 +21,9 @@ func (h *Handlers) GetDevices(c *gin.Context) {
 
 	devices, err := h.tailscaleService.GetDevicesWithContext(c.Request.Context())
 	if err != nil {
+		if writeContextError(c, err) {
+			return
+		}
 		log.Printf("ERROR GetDevices: %v", err)
 		c.JSON(http.StatusOK, gin.H{"devices": []services.Device{}})
 		return
@@ -83,6 +86,9 @@ func (h *Handlers) GetServicesAndRecords(c *gin.Context) {
 func (h *Handlers) GetDNSNameservers(c *gin.Context) {
 	nameservers, err := h.tailscaleService.GetDNSNameserversWithContext(c.Request.Context())
 	if err != nil {
+		if writeContextError(c, err) {
+			return
+		}
 		log.Printf("ERROR GetDNSNameservers: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "Failed to fetch DNS nameservers",

--- a/backend/internal/handlers/device_handlers.go
+++ b/backend/internal/handlers/device_handlers.go
@@ -53,7 +53,7 @@ func (h *Handlers) GetServicesAndRecords(c *gin.Context) {
 }
 
 func (h *Handlers) GetDNSNameservers(c *gin.Context) {
-	nameservers, err := h.tailscaleService.GetDNSNameservers()
+	nameservers, err := h.tailscaleService.GetDNSNameserversWithContext(c.Request.Context())
 	if err != nil {
 		log.Printf("ERROR GetDNSNameservers: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{

--- a/backend/internal/handlers/flow_handlers.go
+++ b/backend/internal/handlers/flow_handlers.go
@@ -146,6 +146,9 @@ func (h *Handlers) GetNetworkLogs(c *gin.Context) {
 	if duration > ChunkThreshold {
 		chunks, err := h.tailscaleService.GetNetworkLogsChunkedParallelWithContext(c.Request.Context(), start, end, ChunkSize, MaxParallelChunks)
 		if err != nil {
+			if writeContextError(c, err) {
+				return
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to fetch network logs",
 				"hint":  "Try selecting a smaller time range",
@@ -208,6 +211,9 @@ func (h *Handlers) GetNetworkLogs(c *gin.Context) {
 
 	logs, err := h.tailscaleService.GetNetworkLogsWithContext(c.Request.Context(), start, end)
 	if err != nil {
+		if writeContextError(c, err) {
+			return
+		}
 		log.Printf("ERROR GetNetworkLogs: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "Failed to fetch network logs",
@@ -254,15 +260,10 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 		return
 	}
 
-	// Calculate bucket size based on time range
+	// Keep the public metadata aligned with the database's query-time bucket
+	// thresholds. The store owns the actual grouping policy.
 	duration := endTime.Sub(startTime)
-	var bucketSize int64 = 60 // 1 minute
-	if duration > 24*time.Hour {
-		bucketSize = 3600 // 1 hour
-	}
-	if duration > 7*24*time.Hour {
-		bucketSize = 86400 // 1 day
-	}
+	bucketSize := bucketSizeForRange(startTime, endTime)
 
 	var aggregates []database.NodePairAggregate
 	source := "database"
@@ -282,8 +283,11 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 		defer cancel()
 
 		// Use pre-computed node pair aggregates
-		aggregates, err = h.store.GetNodePairAggregates(ctx, startTime, endTime, bucketSize)
+		aggregates, err = h.store.GetNodePairAggregates(ctx, startTime, endTime)
 		if err != nil {
+			if writeContextError(c, err) {
+				return
+			}
 			log.Printf("ERROR GetAggregatedFlowLogs: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to fetch aggregated flows",
@@ -401,6 +405,17 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 	})
 }
 
+func bucketSizeForRange(start, end time.Time) int64 {
+	seconds := end.UTC().Unix() - start.UTC().Unix()
+	if seconds <= 2*3600 {
+		return 60
+	}
+	if seconds <= 48*3600 {
+		return 3600
+	}
+	return 86400
+}
+
 func dominantProtocolFromMap(bytesByProtocol map[int]int64, ports []database.PortStat, fallbackProtocols string) int {
 	var dominant, dominantBytes int64
 	for protocol, bytes := range bytesByProtocol {
@@ -429,6 +444,9 @@ func (h *Handlers) GetDataRange(c *gin.Context) {
 
 	dataRange, err := h.store.GetDataRange(ctx)
 	if err != nil {
+		if writeContextError(c, err) {
+			return
+		}
 		log.Printf("ERROR GetDataRange: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "Failed to get data range",

--- a/backend/internal/handlers/flow_handlers.go
+++ b/backend/internal/handlers/flow_handlers.go
@@ -78,6 +78,19 @@ func mergePortStats(existing, incoming []database.PortStat) []database.PortStat 
 	return result
 }
 
+func mergeProtocolByteStats(existing, incoming map[int]int64) map[int]int64 {
+	if len(existing) == 0 && len(incoming) == 0 {
+		return nil
+	}
+	if existing == nil {
+		existing = make(map[int]int64, len(incoming))
+	}
+	for protocol, bytes := range incoming {
+		existing[protocol] += bytes
+	}
+	return existing
+}
+
 func dominantProtocol(protocolsJSON string, ports []database.PortStat) int {
 	if protocol := parseDominantProtocol(protocolsJSON); protocol != 0 {
 		return protocol
@@ -311,19 +324,24 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 	// and filter by traffic type
 	type mergeKey struct{ src, dst, ttype string }
 	type mergedFlow struct {
-		SrcNodeID      string              `json:"srcNodeId"`
-		DstNodeID      string              `json:"dstNodeId"`
-		SrcDisplayName string              `json:"srcDisplayName,omitempty"`
-		DstDisplayName string              `json:"dstDisplayName,omitempty"`
-		TrafficType    string              `json:"trafficType"`
-		TotalTxBytes   int64               `json:"totalTxBytes"`
-		TotalRxBytes   int64               `json:"totalRxBytes"`
-		TotalTxPkts    int64               `json:"totalTxPkts"`
-		TotalRxPkts    int64               `json:"totalRxPkts"`
-		FlowCount      int64               `json:"flowCount"`
-		Protocol       int                 `json:"protocol"`
-		Ports          []database.PortStat `json:"ports,omitempty"`
-		protocolBytes  map[int]int64
+		SrcNodeID       string              `json:"srcNodeId"`
+		DstNodeID       string              `json:"dstNodeId"`
+		SrcDisplayName  string              `json:"srcDisplayName,omitempty"`
+		DstDisplayName  string              `json:"dstDisplayName,omitempty"`
+		TrafficType     string              `json:"trafficType"`
+		TotalTxBytes    int64               `json:"totalTxBytes"`
+		TotalRxBytes    int64               `json:"totalRxBytes"`
+		TotalTxPkts     int64               `json:"totalTxPkts"`
+		TotalRxPkts     int64               `json:"totalRxPkts"`
+		FlowCount       int64               `json:"flowCount"`
+		Protocol        int                 `json:"protocol"`
+		Ports           []database.PortStat `json:"ports,omitempty"`
+		Directional     bool                `json:"directional"`
+		TxProtocolBytes map[int]int64       `json:"txProtocolBytes,omitempty"`
+		RxProtocolBytes map[int]int64       `json:"rxProtocolBytes,omitempty"`
+		TxPorts         []database.PortStat `json:"txPorts,omitempty"`
+		RxPorts         []database.PortStat `json:"rxPorts,omitempty"`
+		protocolBytes   map[int]int64
 	}
 	merged := make(map[mergeKey]*mergedFlow)
 
@@ -338,6 +356,17 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 		key := mergeKey{srcID, dstID, agg.TrafficType}
 		ports := parsePortStats(agg.Ports)
 		protocolBytes := parseProtocolBytes(agg.ProtocolBytes, agg.Protocols, agg.TxBytes+agg.RxBytes)
+		var txProtocolBytes, rxProtocolBytes map[int]int64
+		var txPorts, rxPorts []database.PortStat
+		if agg.DirectionalPorts {
+			// Directional metadata is trustworthy only when the aggregate says
+			// that every row contributing to it preserved direction. Do not
+			// infer direction from legacy union metadata.
+			txProtocolBytes = parseProtocolBytes(agg.TxProtocolBytes, "", 0)
+			rxProtocolBytes = parseProtocolBytes(agg.RxProtocolBytes, "", 0)
+			txPorts = parsePortStats(agg.TxPorts)
+			rxPorts = parsePortStats(agg.RxPorts)
+		}
 
 		if existing, ok := merged[key]; ok {
 			// Merge into existing entry
@@ -351,19 +380,38 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 			}
 			existing.Ports = mergePortStats(existing.Ports, ports)
 			existing.Protocol = dominantProtocolFromMap(existing.protocolBytes, existing.Ports, agg.Protocols)
+			if existing.Directional && agg.DirectionalPorts {
+				existing.TxProtocolBytes = mergeProtocolByteStats(existing.TxProtocolBytes, txProtocolBytes)
+				existing.RxProtocolBytes = mergeProtocolByteStats(existing.RxProtocolBytes, rxProtocolBytes)
+				existing.TxPorts = mergePortStats(existing.TxPorts, txPorts)
+				existing.RxPorts = mergePortStats(existing.RxPorts, rxPorts)
+			} else {
+				// A single legacy contribution makes the merged directional
+				// metadata unreliable for the complete response range.
+				existing.Directional = false
+				existing.TxProtocolBytes = nil
+				existing.RxProtocolBytes = nil
+				existing.TxPorts = nil
+				existing.RxPorts = nil
+			}
 		} else {
 			flow := &mergedFlow{
-				SrcNodeID:     srcID,
-				DstNodeID:     dstID,
-				TrafficType:   agg.TrafficType,
-				TotalTxBytes:  agg.TxBytes,
-				TotalRxBytes:  agg.RxBytes,
-				TotalTxPkts:   agg.TxPkts,
-				TotalRxPkts:   agg.RxPkts,
-				FlowCount:     agg.FlowCount,
-				Protocol:      dominantProtocolFromBytes(agg.ProtocolBytes, agg.Protocols, agg.TxBytes+agg.RxBytes, ports),
-				Ports:         ports,
-				protocolBytes: protocolBytes,
+				SrcNodeID:       srcID,
+				DstNodeID:       dstID,
+				TrafficType:     agg.TrafficType,
+				TotalTxBytes:    agg.TxBytes,
+				TotalRxBytes:    agg.RxBytes,
+				TotalTxPkts:     agg.TxPkts,
+				TotalRxPkts:     agg.RxPkts,
+				FlowCount:       agg.FlowCount,
+				Protocol:        dominantProtocolFromBytes(agg.ProtocolBytes, agg.Protocols, agg.TxBytes+agg.RxBytes, ports),
+				Ports:           ports,
+				Directional:     agg.DirectionalPorts,
+				TxProtocolBytes: txProtocolBytes,
+				RxProtocolBytes: rxProtocolBytes,
+				TxPorts:         txPorts,
+				RxPorts:         rxPorts,
+				protocolBytes:   protocolBytes,
 			}
 			if name := h.resolveNodeName(srcID); name != "" {
 				flow.SrcDisplayName = name

--- a/backend/internal/handlers/flow_handlers.go
+++ b/backend/internal/handlers/flow_handlers.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -298,11 +297,14 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 	}
 
 	// Optional traffic type filter (comma-separated, e.g. "virtual,subnet")
+	trafficTypes, trafficTypesErr := parseBandwidthTrafficTypes(c.Query("trafficTypes"))
+	if trafficTypesErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": trafficTypesErr.Error()})
+		return
+	}
 	trafficFilter := make(map[string]bool)
-	if tf := c.Query("trafficTypes"); tf != "" {
-		for _, t := range strings.Split(tf, ",") {
-			trafficFilter[strings.TrimSpace(t)] = true
-		}
+	for _, trafficType := range trafficTypes {
+		trafficFilter[trafficType] = true
 	}
 
 	// Normalize node IDs, add display names, merge duplicates after normalization,

--- a/backend/internal/handlers/flow_handlers.go
+++ b/backend/internal/handlers/flow_handlers.go
@@ -382,7 +382,10 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 		if flows[i].SrcNodeID != flows[j].SrcNodeID {
 			return flows[i].SrcNodeID < flows[j].SrcNodeID
 		}
-		return flows[i].DstNodeID < flows[j].DstNodeID
+		if flows[i].DstNodeID != flows[j].DstNodeID {
+			return flows[i].DstNodeID < flows[j].DstNodeID
+		}
+		return flows[i].TrafficType < flows[j].TrafficType
 	})
 
 	c.JSON(http.StatusOK, gin.H{

--- a/backend/internal/handlers/flow_handlers.go
+++ b/backend/internal/handlers/flow_handlers.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -25,65 +27,124 @@ func parseDominantProtocol(protocolsJSON string) int {
 	return protos[0] // first element is the most common (sorted by aggregator)
 }
 
+func parsePortStats(portsJSON string) []database.PortStat {
+	if portsJSON == "" || portsJSON == "[]" {
+		return nil
+	}
+	var ports []database.PortStat
+	if err := json.Unmarshal([]byte(portsJSON), &ports); err != nil {
+		return nil
+	}
+	sort.SliceStable(ports, func(i, j int) bool {
+		if ports[i].Bytes == ports[j].Bytes {
+			if ports[i].Proto == ports[j].Proto {
+				return ports[i].Port < ports[j].Port
+			}
+			return ports[i].Proto < ports[j].Proto
+		}
+		return ports[i].Bytes > ports[j].Bytes
+	})
+	return ports
+}
+
+func mergePortStats(existing, incoming []database.PortStat) []database.PortStat {
+	merged := make(map[[2]int]int64, len(existing)+len(incoming))
+	for _, stat := range existing {
+		merged[[2]int{stat.Proto, stat.Port}] += stat.Bytes
+	}
+	for _, stat := range incoming {
+		merged[[2]int{stat.Proto, stat.Port}] += stat.Bytes
+	}
+
+	result := make([]database.PortStat, 0, len(merged))
+	for key, bytes := range merged {
+		result = append(result, database.PortStat{
+			Proto: key[0],
+			Port:  key[1],
+			Bytes: bytes,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Bytes != result[j].Bytes {
+			return result[i].Bytes > result[j].Bytes
+		}
+		if result[i].Proto != result[j].Proto {
+			return result[i].Proto < result[j].Proto
+		}
+		return result[i].Port < result[j].Port
+	})
+	if len(result) > 20 {
+		result = result[:20]
+	}
+	return result
+}
+
+func dominantProtocol(protocolsJSON string, ports []database.PortStat) int {
+	if protocol := parseDominantProtocol(protocolsJSON); protocol != 0 {
+		return protocol
+	}
+	if len(ports) > 0 {
+		return ports[0].Proto
+	}
+	return 0
+}
+
+func parseProtocolBytes(protocolBytesJSON, protocolsJSON string, totalBytes int64) map[int]int64 {
+	result := make(map[int]int64)
+	var raw map[string]int64
+	if json.Unmarshal([]byte(protocolBytesJSON), &raw) == nil && len(raw) > 0 {
+		for key, bytes := range raw {
+			var protocol int
+			if _, err := fmt.Sscanf(key, "%d", &protocol); err == nil {
+				result[protocol] += bytes
+			}
+		}
+		return result
+	}
+
+	var protocols []int
+	if json.Unmarshal([]byte(protocolsJSON), &protocols) != nil || len(protocols) == 0 {
+		return result
+	}
+	perProtocol := totalBytes / int64(len(protocols))
+	remainder := totalBytes - perProtocol*int64(len(protocols))
+	for i, protocol := range protocols {
+		bytes := perProtocol
+		if i == 0 {
+			bytes += remainder
+		}
+		result[protocol] += bytes
+	}
+	return result
+}
+
+func dominantProtocolFromBytes(protocolBytesJSON, protocolsJSON string, totalBytes int64, ports []database.PortStat) int {
+	bytesByProtocol := parseProtocolBytes(protocolBytesJSON, protocolsJSON, totalBytes)
+	var dominant, dominantBytes int64
+	for protocol, bytes := range bytesByProtocol {
+		if bytes > dominantBytes || (bytes == dominantBytes && protocol < int(dominant)) {
+			dominant = int64(protocol)
+			dominantBytes = bytes
+		}
+	}
+	if dominantBytes > 0 || len(bytesByProtocol) > 0 {
+		return int(dominant)
+	}
+	return dominantProtocol(protocolsJSON, ports)
+}
+
 func (h *Handlers) GetNetworkLogs(c *gin.Context) {
-	start := c.Query("start")
-	end := c.Query("end")
-
-	if start == "" || end == "" {
-		now := time.Now()
-		start = now.Add(-5 * time.Minute).Format(time.RFC3339)
-		end = now.Format(time.RFC3339)
-	}
-
-	st, err := time.Parse(time.RFC3339, start)
+	st, et, err := h.parseTimeRange(c)
 	if err != nil {
-		log.Printf("ERROR GetNetworkLogs: invalid start time %s: %v", start, err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "invalid start time format, expected RFC3339",
-		})
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-
-	et, err := time.Parse(time.RFC3339, end)
-	if err != nil {
-		log.Printf("ERROR GetNetworkLogs: invalid end time %s: %v", end, err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid end time format, expected RFC3339"})
-		return
-	}
-
-	if et.Before(st) {
-		log.Printf("ERROR GetNetworkLogs: end time before start time: %s < %s", end, start)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "end time before start time"})
-		return
-	}
-
-	now := time.Now()
-	if st.After(now) {
-		log.Printf("ERROR GetNetworkLogs: future start time not allowed: %s", start)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "future start time not allowed"})
-		return
-	}
-
-	// Clamp future end times to now
-	if et.After(now) {
-		et = now
-		end = et.Format(time.RFC3339)
-	}
-
+	start := st.Format(time.RFC3339)
+	end := et.Format(time.RFC3339)
 	duration := et.Sub(st)
-
-	// Cap maximum query range to 90 days
-	const maxQueryRange = 90 * 24 * time.Hour
-	if duration > maxQueryRange {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "time range too large",
-			"hint":  "maximum query range is 90 days",
-		})
-		return
-	}
 	// Use chunking for queries longer than threshold to prevent response size issues
 	if duration > ChunkThreshold {
-		chunks, err := h.tailscaleService.GetNetworkLogsChunkedParallel(start, end, ChunkSize, MaxParallelChunks)
+		chunks, err := h.tailscaleService.GetNetworkLogsChunkedParallelWithContext(c.Request.Context(), start, end, ChunkSize, MaxParallelChunks)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to fetch network logs",
@@ -128,21 +189,9 @@ func (h *Handlers) GetNetworkLogs(c *gin.Context) {
 			}
 		}
 
-		// Sample logs if too many to prevent response size issues
-		finalLogs := allLogs
-		if len(allLogs) > MaxLogsInResponse {
-			sampleRate := max(len(allLogs)/MaxLogsInResponse, 1)
-			sampledLogs := make([]any, 0, MaxLogsInResponse)
-			for i := 0; i < len(allLogs); i += sampleRate {
-				sampledLogs = append(sampledLogs, allLogs[i])
-			}
-			finalLogs = sampledLogs
-		}
-
-		sampleRate := 1
-		if len(finalLogs) > 0 && len(allLogs) >= len(finalLogs) {
-			sampleRate = len(allLogs) / len(finalLogs)
-		}
+		// Sample logs if too many to prevent response size issues. The interval
+		// uses ceiling division so the response can never exceed the cap.
+		finalLogs, sampleRate := sampleLogs(allLogs, MaxLogsInResponse)
 		c.JSON(http.StatusOK, gin.H{
 			"logs": finalLogs,
 			"metadata": gin.H{
@@ -157,7 +206,7 @@ func (h *Handlers) GetNetworkLogs(c *gin.Context) {
 		return
 	}
 
-	logs, err := h.tailscaleService.GetNetworkLogs(start, end)
+	logs, err := h.tailscaleService.GetNetworkLogsWithContext(c.Request.Context(), start, end)
 	if err != nil {
 		log.Printf("ERROR GetNetworkLogs: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -169,8 +218,24 @@ func (h *Handlers) GetNetworkLogs(c *gin.Context) {
 	c.JSON(http.StatusOK, logs)
 }
 
+func sampleLogs(logs []any, maxCount int) ([]any, int) {
+	if maxCount <= 0 || len(logs) <= maxCount {
+		return logs, 1
+	}
+	interval := (len(logs) + maxCount - 1) / maxCount
+	sampled := make([]any, 0, (len(logs)+interval-1)/interval)
+	for i := 0; i < len(logs); i += interval {
+		sampled = append(sampled, logs[i])
+	}
+	return sampled, interval
+}
+
 func (h *Handlers) GetStoredFlowLogs(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"logs": []any{}})
+	c.Header("Deprecation", "true")
+	c.JSON(http.StatusGone, gin.H{
+		"error":       "raw flow logs are no longer stored",
+		"replacement": "/api/flow-logs/aggregated",
+	})
 }
 
 // GetAggregatedFlowLogs returns pre-aggregated node-to-node traffic
@@ -183,39 +248,9 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 		return
 	}
 
-	start := c.Query("start")
-	end := c.Query("end")
-
-	var startTime, endTime time.Time
-	var err error
-
-	if start == "" {
-		startTime = time.Now().Add(-1 * time.Hour)
-	} else {
-		startTime, err = time.Parse(time.RFC3339, start)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid start time"})
-			return
-		}
-	}
-
-	if end == "" {
-		endTime = time.Now()
-	} else {
-		endTime, err = time.Parse(time.RFC3339, end)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid end time"})
-			return
-		}
-	}
-
-	// Clamp future end times to now
-	if endTime.After(time.Now()) {
-		endTime = time.Now()
-	}
-
-	if endTime.Before(startTime) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "end time before start time"})
+	startTime, endTime, err := h.parseTimeRange(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -235,7 +270,7 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 	// Try rolling cache first for recent data (within last hour)
 	if h.poller != nil && duration <= time.Hour {
 		cache := h.poller.GetRollingCache()
-		if cache.HasDataFor(startTime, endTime) {
+		if cache.HasNodePairDataFor(startTime, endTime) {
 			aggregates = cache.GetNodePairs(startTime, endTime)
 			source = "cache"
 		}
@@ -269,7 +304,22 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 	// Normalize node IDs, add display names, merge duplicates after normalization,
 	// and filter by traffic type
 	type mergeKey struct{ src, dst, ttype string }
-	merged := make(map[mergeKey]*gin.H)
+	type mergedFlow struct {
+		SrcNodeID      string              `json:"srcNodeId"`
+		DstNodeID      string              `json:"dstNodeId"`
+		SrcDisplayName string              `json:"srcDisplayName,omitempty"`
+		DstDisplayName string              `json:"dstDisplayName,omitempty"`
+		TrafficType    string              `json:"trafficType"`
+		TotalTxBytes   int64               `json:"totalTxBytes"`
+		TotalRxBytes   int64               `json:"totalRxBytes"`
+		TotalTxPkts    int64               `json:"totalTxPkts"`
+		TotalRxPkts    int64               `json:"totalRxPkts"`
+		FlowCount      int64               `json:"flowCount"`
+		Protocol       int                 `json:"protocol"`
+		Ports          []database.PortStat `json:"ports,omitempty"`
+		protocolBytes  map[int]int64
+	}
+	merged := make(map[mergeKey]*mergedFlow)
 
 	for _, agg := range aggregates {
 		// Apply traffic type filter
@@ -280,40 +330,60 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 		srcID := h.resolveNodeID(agg.SrcNodeID)
 		dstID := h.resolveNodeID(agg.DstNodeID)
 		key := mergeKey{srcID, dstID, agg.TrafficType}
+		ports := parsePortStats(agg.Ports)
+		protocolBytes := parseProtocolBytes(agg.ProtocolBytes, agg.Protocols, agg.TxBytes+agg.RxBytes)
 
 		if existing, ok := merged[key]; ok {
 			// Merge into existing entry
-			(*existing)["totalTxBytes"] = (*existing)["totalTxBytes"].(int64) + agg.TxBytes
-			(*existing)["totalRxBytes"] = (*existing)["totalRxBytes"].(int64) + agg.RxBytes
-			(*existing)["totalTxPkts"] = (*existing)["totalTxPkts"].(int64) + agg.TxPkts
-			(*existing)["totalRxPkts"] = (*existing)["totalRxPkts"].(int64) + agg.RxPkts
-			(*existing)["flowCount"] = (*existing)["flowCount"].(int64) + agg.FlowCount
+			existing.TotalTxBytes += agg.TxBytes
+			existing.TotalRxBytes += agg.RxBytes
+			existing.TotalTxPkts += agg.TxPkts
+			existing.TotalRxPkts += agg.RxPkts
+			existing.FlowCount += agg.FlowCount
+			for protocol, bytes := range protocolBytes {
+				existing.protocolBytes[protocol] += bytes
+			}
+			existing.Ports = mergePortStats(existing.Ports, ports)
+			existing.Protocol = dominantProtocolFromMap(existing.protocolBytes, existing.Ports, agg.Protocols)
 		} else {
-			flow := gin.H{
-				"srcNodeId":    srcID,
-				"dstNodeId":    dstID,
-				"trafficType":  agg.TrafficType,
-				"totalTxBytes": agg.TxBytes,
-				"totalRxBytes": agg.RxBytes,
-				"totalTxPkts":  agg.TxPkts,
-				"totalRxPkts":  agg.RxPkts,
-				"flowCount":    agg.FlowCount,
-				"protocol":     parseDominantProtocol(agg.Protocols),
+			flow := &mergedFlow{
+				SrcNodeID:     srcID,
+				DstNodeID:     dstID,
+				TrafficType:   agg.TrafficType,
+				TotalTxBytes:  agg.TxBytes,
+				TotalRxBytes:  agg.RxBytes,
+				TotalTxPkts:   agg.TxPkts,
+				TotalRxPkts:   agg.RxPkts,
+				FlowCount:     agg.FlowCount,
+				Protocol:      dominantProtocolFromBytes(agg.ProtocolBytes, agg.Protocols, agg.TxBytes+agg.RxBytes, ports),
+				Ports:         ports,
+				protocolBytes: protocolBytes,
 			}
 			if name := h.resolveNodeName(srcID); name != "" {
-				flow["srcDisplayName"] = name
+				flow.SrcDisplayName = name
 			}
 			if name := h.resolveNodeName(dstID); name != "" {
-				flow["dstDisplayName"] = name
+				flow.DstDisplayName = name
 			}
-			merged[key] = &flow
+			merged[key] = flow
 		}
 	}
 
-	flows := make([]gin.H, 0, len(merged))
+	flows := make([]mergedFlow, 0, len(merged))
 	for _, flow := range merged {
 		flows = append(flows, *flow)
 	}
+	sort.Slice(flows, func(i, j int) bool {
+		left := flows[i].TotalTxBytes + flows[i].TotalRxBytes
+		right := flows[j].TotalTxBytes + flows[j].TotalRxBytes
+		if left != right {
+			return left > right
+		}
+		if flows[i].SrcNodeID != flows[j].SrcNodeID {
+			return flows[i].SrcNodeID < flows[j].SrcNodeID
+		}
+		return flows[i].DstNodeID < flows[j].DstNodeID
+	})
 
 	c.JSON(http.StatusOK, gin.H{
 		"flows": flows,
@@ -326,6 +396,20 @@ func (h *Handlers) GetAggregatedFlowLogs(c *gin.Context) {
 			"truncated":  false,
 		},
 	})
+}
+
+func dominantProtocolFromMap(bytesByProtocol map[int]int64, ports []database.PortStat, fallbackProtocols string) int {
+	var dominant, dominantBytes int64
+	for protocol, bytes := range bytesByProtocol {
+		if bytes > dominantBytes || (bytes == dominantBytes && protocol < int(dominant)) {
+			dominant = int64(protocol)
+			dominantBytes = bytes
+		}
+	}
+	if dominantBytes > 0 || len(bytesByProtocol) > 0 {
+		return int(dominant)
+	}
+	return dominantProtocol(fallbackProtocols, ports)
 }
 
 // GetDataRange returns the available time range of stored data

--- a/backend/internal/handlers/flow_handlers_regression_test.go
+++ b/backend/internal/handlers/flow_handlers_regression_test.go
@@ -233,6 +233,111 @@ func TestAggregatedFlowsRejectInvalidTrafficType(t *testing.T) {
 	}
 }
 
+func TestStatsOverviewMergesMissingDerivedBucketsAndKeepsPrimaryOverlap(t *testing.T) {
+	store := setupHandlerTestDB(t)
+	base := time.Now().UTC().Truncate(time.Minute).Add(-3 * time.Minute)
+	ctx := context.Background()
+	if err := store.UpsertTrafficStats(ctx, []database.TrafficStats{
+		{Bucket: base.Unix(), TCPBytes: 100, VirtualBytes: 100, TotalFlows: 1, UniquePairs: 1},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertNodePairAggregates(ctx, []database.NodePairAggregate{
+		// This overlaps the authoritative traffic_stats bucket and must not be added to it.
+		{Bucket: base.Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual", TxBytes: 900, FlowCount: 9, Protocols: "[17]", ProtocolBytes: `{"17":900}`},
+		// This bucket exists only in node_pairs and must be included.
+		{Bucket: base.Add(time.Minute).Unix(), SrcNodeID: "c", DstNodeID: "d", TrafficType: "virtual", TxBytes: 200, FlowCount: 2, Protocols: "[17]", ProtocolBytes: `{"17":200}`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	response := getStatsOverviewResponse(t, store, base, base.Add(2*time.Minute))
+	if len(response.Buckets) != 2 {
+		t.Fatalf("bucket count = %d, want 2: %+v", len(response.Buckets), response.Buckets)
+	}
+	if response.Buckets[0].Bucket != base.Unix() || response.Buckets[1].Bucket != base.Add(time.Minute).Unix() {
+		t.Fatalf("bucket order = %+v", response.Buckets)
+	}
+	if response.Buckets[0].TCPBytes != 100 || response.Buckets[0].UDPBytes != 0 || response.Buckets[0].TotalFlows != 1 {
+		t.Fatalf("overlapping primary bucket was changed: %+v", response.Buckets[0])
+	}
+	if response.Buckets[1].UDPBytes != 200 || response.Buckets[1].VirtualBytes != 200 || response.Buckets[1].TotalFlows != 2 {
+		t.Fatalf("derived bucket = %+v", response.Buckets[1])
+	}
+	if response.Summary.TCPBytes != 100 || response.Summary.UDPBytes != 200 || response.Summary.VirtualBytes != 300 || response.Summary.TotalFlows != 3 {
+		t.Fatalf("summary = %+v", response.Summary)
+	}
+	if response.Metadata.Source != "database" {
+		t.Fatalf("source = %q, want database", response.Metadata.Source)
+	}
+}
+
+func TestStatsOverviewFallsBackToDerivedBucketsWhenTrafficStatsIsEmpty(t *testing.T) {
+	store := setupHandlerTestDB(t)
+	base := time.Now().UTC().Truncate(time.Minute).Add(-3 * time.Minute)
+	if err := store.UpsertNodePairAggregates(context.Background(), []database.NodePairAggregate{
+		{Bucket: base.Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "exit", TxBytes: 75, FlowCount: 1, Protocols: "[6]", ProtocolBytes: `{"6":75}`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	response := getStatsOverviewResponse(t, store, base, base.Add(time.Minute))
+	if len(response.Buckets) != 1 || response.Buckets[0].Bucket != base.Unix() {
+		t.Fatalf("fallback buckets = %+v", response.Buckets)
+	}
+	if response.Buckets[0].TCPBytes != 75 || response.Buckets[0].ExitBytes != 75 || response.Buckets[0].TotalFlows != 1 {
+		t.Fatalf("fallback bucket = %+v", response.Buckets[0])
+	}
+	if response.Summary.TCPBytes != 75 || response.Summary.ExitBytes != 75 || response.Summary.TotalFlows != 1 {
+		t.Fatalf("fallback summary = %+v", response.Summary)
+	}
+	if response.Metadata.Source != "database (derived)" {
+		t.Fatalf("source = %q, want database (derived)", response.Metadata.Source)
+	}
+}
+
+type statsOverviewResponse struct {
+	Summary struct {
+		TCPBytes        int64 `json:"tcpBytes"`
+		UDPBytes        int64 `json:"udpBytes"`
+		OtherProtoBytes int64 `json:"otherProtoBytes"`
+		VirtualBytes    int64 `json:"virtualBytes"`
+		ExitBytes       int64 `json:"exitBytes"`
+		SubnetBytes     int64 `json:"subnetBytes"`
+		PhysicalBytes   int64 `json:"physicalBytes"`
+		TotalFlows      int64 `json:"totalFlows"`
+		UniquePairs     int64 `json:"uniquePairs"`
+	} `json:"summary"`
+	Buckets []struct {
+		Bucket       int64 `json:"bucket"`
+		TCPBytes     int64 `json:"tcpBytes"`
+		UDPBytes     int64 `json:"udpBytes"`
+		VirtualBytes int64 `json:"virtualBytes"`
+		ExitBytes    int64 `json:"exitBytes"`
+		TotalFlows   int64 `json:"totalFlows"`
+	} `json:"buckets"`
+	Metadata struct {
+		Source string `json:"source"`
+	} `json:"metadata"`
+}
+
+func getStatsOverviewResponse(t *testing.T, store *database.SQLiteStore, start, end time.Time) statsOverviewResponse {
+	t.Helper()
+	h := &Handlers{store: store}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/stats/overview?start="+start.Format(time.RFC3339)+"&end="+end.Format(time.RFC3339), nil)
+	h.GetStatsOverview(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var response statsOverviewResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
 func setupHandlerTestDB(t *testing.T) *database.SQLiteStore {
 	t.Helper()
 	store, err := database.NewSQLiteStore(t.TempDir() + "/test.db")

--- a/backend/internal/handlers/flow_handlers_regression_test.go
+++ b/backend/internal/handlers/flow_handlers_regression_test.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rajsinghtech/tsflow/backend/internal/database"
+)
+
+func TestSampleLogsNeverExceedsCap(t *testing.T) {
+	logs := make([]any, 99999)
+	sampled, interval := sampleLogs(logs, 50000)
+	if len(sampled) > 50000 {
+		t.Fatalf("sampled %d logs, cap is 50000", len(sampled))
+	}
+	if interval != 2 || len(sampled) != 50000 {
+		t.Fatalf("interval=%d sampled=%d, want interval=2 sampled=50000", interval, len(sampled))
+	}
+}
+
+func TestDeprecatedFlowEndpointsReturnGone(t *testing.T) {
+	h := &Handlers{}
+	for name, handler := range map[string]gin.HandlerFunc{
+		"stored": h.GetStoredFlowLogs,
+		"device": h.GetDeviceFlows,
+	} {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/api/flow-logs", nil)
+			handler(c)
+			if w.Code != http.StatusGone {
+				t.Fatalf("status=%d, want 410", w.Code)
+			}
+		})
+	}
+}
+
+func TestAggregatedFlowMergesPortsAcrossBuckets(t *testing.T) {
+	store := setupHandlerTestDB(t)
+	base := time.Now().UTC().Truncate(time.Minute).Add(-2 * time.Minute)
+	if err := store.UpsertNodePairAggregates(context.Background(), []database.NodePairAggregate{
+		{Bucket: base.Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual", TxBytes: 100, Protocols: "[6]", ProtocolBytes: `{"6":100}`, Ports: `[{"port":443,"proto":6,"bytes":100}]`},
+		{Bucket: base.Add(time.Minute).Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual", TxBytes: 300, Protocols: "[17]", ProtocolBytes: `{"17":300}`, Ports: `[{"port":53,"proto":17,"bytes":300}]`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := &Handlers{store: store}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/flow-logs/aggregated?start="+base.Format(time.RFC3339)+"&end="+base.Add(2*time.Minute).Format(time.RFC3339), nil)
+	h.GetAggregatedFlowLogs(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var response struct {
+		Flows []struct {
+			Protocol int                 `json:"protocol"`
+			Ports    []database.PortStat `json:"ports"`
+		} `json:"flows"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Flows) != 1 || response.Flows[0].Protocol != 17 {
+		t.Fatalf("unexpected flow response: %+v", response.Flows)
+	}
+	if len(response.Flows[0].Ports) != 2 || response.Flows[0].Ports[0].Port != 53 || response.Flows[0].Ports[1].Port != 443 {
+		t.Fatalf("ports were not merged: %+v", response.Flows[0].Ports)
+	}
+}
+
+func setupHandlerTestDB(t *testing.T) *database.SQLiteStore {
+	t.Helper()
+	store, err := database.NewSQLiteStore(t.TempDir() + "/test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Init(context.Background()); err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}

--- a/backend/internal/handlers/flow_handlers_regression_test.go
+++ b/backend/internal/handlers/flow_handlers_regression_test.go
@@ -61,8 +61,9 @@ func TestAggregatedFlowMergesPortsAcrossBuckets(t *testing.T) {
 	}
 	var response struct {
 		Flows []struct {
-			Protocol int                 `json:"protocol"`
-			Ports    []database.PortStat `json:"ports"`
+			Protocol    int                 `json:"protocol"`
+			Ports       []database.PortStat `json:"ports"`
+			Directional bool                `json:"directional"`
 		} `json:"flows"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
@@ -73,6 +74,134 @@ func TestAggregatedFlowMergesPortsAcrossBuckets(t *testing.T) {
 	}
 	if len(response.Flows[0].Ports) != 2 || response.Flows[0].Ports[0].Port != 53 || response.Flows[0].Ports[1].Port != 443 {
 		t.Fatalf("ports were not merged: %+v", response.Flows[0].Ports)
+	}
+	if response.Flows[0].Directional {
+		t.Fatalf("legacy aggregate unexpectedly marked directional: %+v", response.Flows[0])
+	}
+}
+
+func TestAggregatedFlowExposesDirectionalMetadata(t *testing.T) {
+	store := setupHandlerTestDB(t)
+	base := time.Now().UTC().Truncate(time.Minute).Add(-2 * time.Minute)
+	if err := store.UpsertNodePairAggregates(context.Background(), []database.NodePairAggregate{
+		{
+			Bucket: base.Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+			TxBytes: 100, RxBytes: 200, Protocols: "[17,6]", ProtocolBytes: `{"6":100,"17":200}`,
+			Ports:           `[ {"port":53,"proto":17,"bytes":200}, {"port":443,"proto":6,"bytes":100} ]`,
+			TxProtocolBytes: `{"6":100}`, RxProtocolBytes: `{"17":200}`,
+			TxPorts: `[ {"port":443,"proto":6,"bytes":100} ]`, RxPorts: `[ {"port":53,"proto":17,"bytes":200} ]`,
+			DirectionalPorts: true,
+		},
+		{
+			Bucket: base.Add(time.Minute).Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+			TxBytes: 300, RxBytes: 400, Protocols: "[17,6]", ProtocolBytes: `{"6":300,"17":400}`,
+			Ports:           `[ {"port":53,"proto":17,"bytes":400}, {"port":443,"proto":6,"bytes":300} ]`,
+			TxProtocolBytes: `{"6":300}`, RxProtocolBytes: `{"17":400}`,
+			TxPorts: `[ {"port":443,"proto":6,"bytes":300} ]`, RxPorts: `[ {"port":53,"proto":17,"bytes":400} ]`,
+			DirectionalPorts: true,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := &Handlers{store: store}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/flow-logs/aggregated?start="+base.Format(time.RFC3339)+"&end="+base.Add(2*time.Minute).Format(time.RFC3339), nil)
+	h.GetAggregatedFlowLogs(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var response struct {
+		Flows []struct {
+			TotalTxBytes    int64               `json:"totalTxBytes"`
+			TotalRxBytes    int64               `json:"totalRxBytes"`
+			Protocol        int                 `json:"protocol"`
+			Directional     bool                `json:"directional"`
+			TxProtocolBytes map[int]int64       `json:"txProtocolBytes"`
+			RxProtocolBytes map[int]int64       `json:"rxProtocolBytes"`
+			TxPorts         []database.PortStat `json:"txPorts"`
+			RxPorts         []database.PortStat `json:"rxPorts"`
+		} `json:"flows"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Flows) != 1 {
+		t.Fatalf("unexpected flow response: %+v", response)
+	}
+	flow := response.Flows[0]
+	if flow.TotalTxBytes != 400 || flow.TotalRxBytes != 600 || flow.Protocol != 17 {
+		t.Fatalf("merged legacy fields = %+v", flow)
+	}
+	if !flow.Directional {
+		t.Fatalf("directional metadata was not exposed: %+v", flow)
+	}
+	if flow.TxProtocolBytes[6] != 400 || len(flow.TxProtocolBytes) != 1 {
+		t.Fatalf("tx protocol bytes = %+v", flow.TxProtocolBytes)
+	}
+	if flow.RxProtocolBytes[17] != 600 || len(flow.RxProtocolBytes) != 1 {
+		t.Fatalf("rx protocol bytes = %+v", flow.RxProtocolBytes)
+	}
+	if len(flow.TxPorts) != 1 || flow.TxPorts[0].Port != 443 || flow.TxPorts[0].Bytes != 400 {
+		t.Fatalf("tx ports = %+v", flow.TxPorts)
+	}
+	if len(flow.RxPorts) != 1 || flow.RxPorts[0].Port != 53 || flow.RxPorts[0].Bytes != 600 {
+		t.Fatalf("rx ports = %+v", flow.RxPorts)
+	}
+}
+
+func TestAggregatedFlowClearsDirectionalMetadataWhenLegacyBucketIsMerged(t *testing.T) {
+	store := setupHandlerTestDB(t)
+	base := time.Now().UTC().Truncate(time.Minute).Add(-2 * time.Minute)
+	if err := store.UpsertNodePairAggregates(context.Background(), []database.NodePairAggregate{
+		{
+			Bucket: base.Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+			TxBytes: 100, Protocols: "[6]", ProtocolBytes: `{"6":100}`,
+			Ports:           `[ {"port":443,"proto":6,"bytes":100} ]`,
+			TxProtocolBytes: `{"6":100}`, TxPorts: `[ {"port":443,"proto":6,"bytes":100} ]`,
+			DirectionalPorts: true,
+		},
+		{
+			Bucket: base.Add(time.Minute).Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+			TxBytes: 200, Protocols: "[17]", ProtocolBytes: `{"17":200}`,
+			Ports: `[ {"port":53,"proto":17,"bytes":200} ]`,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := &Handlers{store: store}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/flow-logs/aggregated?start="+base.Format(time.RFC3339)+"&end="+base.Add(2*time.Minute).Format(time.RFC3339), nil)
+	h.GetAggregatedFlowLogs(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var response struct {
+		Flows []struct {
+			Directional     bool                `json:"directional"`
+			TxProtocolBytes map[int]int64       `json:"txProtocolBytes"`
+			RxProtocolBytes map[int]int64       `json:"rxProtocolBytes"`
+			TxPorts         []database.PortStat `json:"txPorts"`
+			RxPorts         []database.PortStat `json:"rxPorts"`
+		} `json:"flows"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Flows) != 1 {
+		t.Fatalf("unexpected flow response: %+v", response)
+	}
+	flow := response.Flows[0]
+	if flow.Directional {
+		t.Fatalf("legacy contribution did not clear directional metadata: %+v", flow)
+	}
+	if flow.TxProtocolBytes != nil || flow.RxProtocolBytes != nil || flow.TxPorts != nil || flow.RxPorts != nil {
+		t.Fatalf("directional fields survived legacy merge: %+v", flow)
 	}
 }
 

--- a/backend/internal/handlers/flow_handlers_regression_test.go
+++ b/backend/internal/handlers/flow_handlers_regression_test.go
@@ -76,6 +76,34 @@ func TestAggregatedFlowMergesPortsAcrossBuckets(t *testing.T) {
 	}
 }
 
+func TestBandwidthByIPsRejectsEmptyEntries(t *testing.T) {
+	store := setupHandlerTestDB(t)
+	h := &Handlers{store: store}
+	start := time.Now().UTC().Truncate(time.Minute).Add(-time.Minute)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet,
+		"/api/bandwidth?start="+start.Format(time.RFC3339)+"&end="+start.Add(time.Minute).Format(time.RFC3339)+"&ips=100.64.0.1,,100.64.0.2", nil)
+	h.GetBandwidthByIPs(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", w.Code, w.Body.String())
+	}
+}
+
+func TestAggregatedFlowsRejectInvalidTrafficType(t *testing.T) {
+	store := setupHandlerTestDB(t)
+	h := &Handlers{store: store}
+	start := time.Now().UTC().Truncate(time.Minute).Add(-time.Minute)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet,
+		"/api/flow-logs/aggregated?start="+start.Format(time.RFC3339)+"&end="+start.Add(time.Minute).Format(time.RFC3339)+"&trafficTypes=bogus", nil)
+	h.GetAggregatedFlowLogs(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", w.Code, w.Body.String())
+	}
+}
+
 func setupHandlerTestDB(t *testing.T) *database.SQLiteStore {
 	t.Helper()
 	store, err := database.NewSQLiteStore(t.TempDir() + "/test.db")

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,6 +13,22 @@ import (
 	"github.com/rajsinghtech/tsflow/backend/internal/database"
 	"github.com/rajsinghtech/tsflow/backend/internal/services"
 )
+
+// writeContextError converts request cancellation and query deadlines into
+// transport-level statuses consistently across handlers. A canceled request
+// must not be reported as a successful empty response.
+func writeContextError(c *gin.Context, err error) bool {
+	requestErr := c.Request.Context().Err()
+	if errors.Is(err, context.Canceled) || errors.Is(requestErr, context.Canceled) {
+		c.Status(499)
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(requestErr, context.DeadlineExceeded) {
+		c.Status(http.StatusGatewayTimeout)
+		return true
+	}
+	return false
+}
 
 const (
 	// ChunkThreshold is the duration above which log queries are chunked

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -19,8 +19,9 @@ const (
 	ChunkSize = 24 * time.Hour
 	// MaxParallelChunks limits concurrent chunk fetches
 	MaxParallelChunks = 2
-	// MaxLogsInMemory limits logs held in memory during chunked queries
-	MaxLogsInMemory = 10000
+	// MaxLogsInMemory limits logs held in memory during chunked queries. Keep it
+	// above the response cap so the sampling path remains reachable.
+	MaxLogsInMemory = 100000
 	// MaxLogsInResponse limits logs returned in a single response
 	MaxLogsInResponse = 50000
 	// MaxBuckets limits the number of time-series buckets returned

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -155,3 +155,27 @@ func TestGetServicesAndRecordsPropagatesCancellation(t *testing.T) {
 		t.Fatalf("status = %d, want 499 for canceled request", w.Code)
 	}
 }
+
+func TestWriteContextError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "canceled", err: context.Canceled, want: 499},
+		{name: "deadline", err: context.DeadlineExceeded, want: http.StatusGatewayTimeout},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest("GET", "/test", nil)
+			if !writeContextError(c, tc.err) {
+				t.Fatal("writeContextError returned false")
+			}
+			c.Writer.WriteHeaderNow()
+			if w.Code != tc.want {
+				t.Fatalf("status = %d, want %d", w.Code, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -179,3 +179,14 @@ func TestWriteContextError(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBandwidthTrafficTypesRejectsInvalidValues(t *testing.T) {
+	if got, err := parseBandwidthTrafficTypes("virtual, subnet,virtual"); err != nil || len(got) != 2 || got[0] != "virtual" || got[1] != "subnet" {
+		t.Fatalf("valid traffic types = %#v, error = %v", got, err)
+	}
+	for _, raw := range []string{"invalid", "virtual,invalid", "virtual,"} {
+		if got, err := parseBandwidthTrafficTypes(raw); err == nil || got != nil {
+			t.Fatalf("parseBandwidthTrafficTypes(%q) = %#v, error = %v; want validation error", raw, got, err)
+		}
+	}
+}

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rajsinghtech/tsflow/backend/internal/config"
+	"github.com/rajsinghtech/tsflow/backend/internal/services"
 )
 
 func init() {
@@ -127,5 +130,28 @@ func TestResolveNodeOwner_NilPoller(t *testing.T) {
 	h := &Handlers{}
 	if owner := h.resolveNodeOwner("device1"); owner != "" {
 		t.Errorf("expected empty owner with nil poller, got %q", owner)
+	}
+}
+
+func TestGetServicesAndRecordsPropagatesCancellation(t *testing.T) {
+	service := services.NewTailscaleService(&config.Config{
+		TailscaleAPIURL:  "http://127.0.0.1:1",
+		TailscaleTailnet: "example.com",
+	})
+	h := &Handlers{tailscaleService: service}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	requestCtx, cancel := context.WithCancel(context.Background())
+	c.Request = httptest.NewRequest("GET", "/services-records", nil).WithContext(requestCtx)
+	cancel()
+	if _, err := service.GetVIPServices(requestCtx); err == nil {
+		t.Fatal("expected direct VIP service request to return cancellation")
+	}
+
+	h.GetServicesAndRecords(c)
+	c.Writer.WriteHeaderNow()
+
+	if w.Code != 499 {
+		t.Fatalf("status = %d, want 499 for canceled request", w.Code)
 	}
 }

--- a/backend/internal/handlers/network_handlers.go
+++ b/backend/internal/handlers/network_handlers.go
@@ -10,6 +10,9 @@ import (
 func (h *Handlers) GetNetworkMap(c *gin.Context) {
 	networkMap, err := h.tailscaleService.GetNetworkMapWithContext(c.Request.Context())
 	if err != nil {
+		if writeContextError(c, err) {
+			return
+		}
 		log.Printf("ERROR GetNetworkMap: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "Failed to fetch network map",

--- a/backend/internal/handlers/network_handlers.go
+++ b/backend/internal/handlers/network_handlers.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (h *Handlers) GetNetworkMap(c *gin.Context) {
-	networkMap, err := h.tailscaleService.GetNetworkMap()
+	networkMap, err := h.tailscaleService.GetNetworkMapWithContext(c.Request.Context())
 	if err != nil {
 		log.Printf("ERROR GetNetworkMap: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{

--- a/backend/internal/handlers/network_handlers.go
+++ b/backend/internal/handlers/network_handlers.go
@@ -21,8 +21,10 @@ func (h *Handlers) GetNetworkMap(c *gin.Context) {
 }
 
 func (h *Handlers) GetDeviceFlows(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, gin.H{
-		"error":   "Not implemented",
-		"message": "Tailscale does not expose per-device flow data",
+	c.Header("Deprecation", "true")
+	c.JSON(http.StatusGone, gin.H{
+		"error":       "per-device raw flow logs are not stored",
+		"replacement": "/api/flow-logs/aggregated",
+		"message":     "Query aggregated flows and filter by srcNodeId or dstNodeId.",
 	})
 }

--- a/backend/internal/handlers/policy_handlers.go
+++ b/backend/internal/handlers/policy_handlers.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (h *Handlers) GetUsers(c *gin.Context) {
-	users, err := h.tailscaleService.GetUsers()
+	users, err := h.tailscaleService.GetUsersWithContext(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -16,7 +16,7 @@ func (h *Handlers) GetUsers(c *gin.Context) {
 }
 
 func (h *Handlers) GetPolicy(c *gin.Context) {
-	policy, err := h.tailscaleService.GetPolicy()
+	policy, err := h.tailscaleService.GetPolicyWithContext(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/handlers/policy_handlers.go
+++ b/backend/internal/handlers/policy_handlers.go
@@ -9,6 +9,9 @@ import (
 func (h *Handlers) GetUsers(c *gin.Context) {
 	users, err := h.tailscaleService.GetUsersWithContext(c.Request.Context())
 	if err != nil {
+		if writeContextError(c, err) {
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -18,6 +21,9 @@ func (h *Handlers) GetUsers(c *gin.Context) {
 func (h *Handlers) GetPolicy(c *gin.Context) {
 	policy, err := h.tailscaleService.GetPolicyWithContext(c.Request.Context())
 	if err != nil {
+		if writeContextError(c, err) {
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/backend/internal/handlers/poller_handlers.go
+++ b/backend/internal/handlers/poller_handlers.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"errors"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -24,9 +26,22 @@ func (h *Handlers) GetPollerStatus(c *gin.Context) {
 		defer cancel()
 
 		dbStats, err := h.store.GetStats(ctx)
-		if err == nil {
-			stats["database"] = dbStats
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(c.Request.Context().Err(), context.Canceled) {
+				c.Status(499)
+				return
+			}
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(c.Request.Context().Err(), context.DeadlineExceeded) {
+				c.Status(http.StatusGatewayTimeout)
+				return
+			}
+			log.Printf("ERROR GetPollerStatus database stats: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to fetch database stats",
+			})
+			return
 		}
+		stats["database"] = dbStats
 	}
 
 	c.JSON(http.StatusOK, stats)

--- a/backend/internal/handlers/poller_handlers.go
+++ b/backend/internal/handlers/poller_handlers.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"log"
 	"net/http"
 
@@ -27,12 +26,7 @@ func (h *Handlers) GetPollerStatus(c *gin.Context) {
 
 		dbStats, err := h.store.GetStats(ctx)
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(c.Request.Context().Err(), context.Canceled) {
-				c.Status(499)
-				return
-			}
-			if errors.Is(err, context.DeadlineExceeded) || errors.Is(c.Request.Context().Err(), context.DeadlineExceeded) {
-				c.Status(http.StatusGatewayTimeout)
+			if writeContextError(c, err) {
 				return
 			}
 			log.Printf("ERROR GetPollerStatus database stats: %v", err)

--- a/backend/internal/handlers/stats_handlers.go
+++ b/backend/internal/handlers/stats_handlers.go
@@ -84,13 +84,14 @@ func (h *Handlers) GetStatsOverview(c *gin.Context) {
 
 	// Aggregate buckets into summary
 	var tcpBytes, udpBytes, otherProtoBytes int64
-	var virtualBytes, subnetBytes, physicalBytes int64
+	var virtualBytes, exitBytes, subnetBytes, physicalBytes int64
 	var totalFlows, maxUniquePairs int64
 	for _, b := range buckets {
 		tcpBytes += b.TCPBytes
 		udpBytes += b.UDPBytes
 		otherProtoBytes += b.OtherProtoBytes
 		virtualBytes += b.VirtualBytes
+		exitBytes += b.ExitBytes
 		subnetBytes += b.SubnetBytes
 		physicalBytes += b.PhysicalBytes
 		totalFlows += b.TotalFlows
@@ -105,6 +106,7 @@ func (h *Handlers) GetStatsOverview(c *gin.Context) {
 			"udpBytes":        udpBytes,
 			"otherProtoBytes": otherProtoBytes,
 			"virtualBytes":    virtualBytes,
+			"exitBytes":       exitBytes,
 			"subnetBytes":     subnetBytes,
 			"physicalBytes":   physicalBytes,
 			"totalFlows":      totalFlows,

--- a/backend/internal/handlers/stats_handlers.go
+++ b/backend/internal/handlers/stats_handlers.go
@@ -49,6 +49,9 @@ func (h *Handlers) GetStatsOverview(c *gin.Context) {
 			buckets, err = h.store.GetTrafficStats(ctx, startTime, endTime)
 		}
 		if err != nil {
+			if writeContextError(c, err) {
+				return
+			}
 			log.Printf("ERROR GetStatsOverview: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to fetch traffic stats",
@@ -61,7 +64,14 @@ func (h *Handlers) GetStatsOverview(c *gin.Context) {
 		if len(buckets) == 0 && len(trafficTypes) == 0 {
 			buckets, err = h.store.GetTrafficStatsFromNodePairs(ctx, startTime, endTime)
 			if err != nil {
+				if writeContextError(c, err) {
+					return
+				}
 				log.Printf("ERROR GetStatsOverview (fallback): %v", err)
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": "Failed to fetch derived traffic stats",
+				})
+				return
 			} else {
 				source = "database (derived)"
 			}
@@ -134,6 +144,9 @@ func (h *Handlers) GetTopTalkers(c *gin.Context) {
 		talkers, err = h.store.GetTopTalkers(ctx, startTime, endTime, limit*10)
 	}
 	if err != nil {
+		if writeContextError(c, err) {
+			return
+		}
 		log.Printf("ERROR GetTopTalkers: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "Failed to fetch top talkers",
@@ -235,6 +248,9 @@ func (h *Handlers) GetTopPairs(c *gin.Context) {
 		pairs, err = h.store.GetTopPairs(ctx, startTime, endTime, limit*10)
 	}
 	if err != nil {
+		if writeContextError(c, err) {
+			return
+		}
 		log.Printf("ERROR GetTopPairs: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "Failed to fetch top pairs",
@@ -354,6 +370,9 @@ func (h *Handlers) GetNodeDetailStats(c *gin.Context) {
 
 	stats, err := h.store.GetNodeStats(ctx, nodeID, startTime, endTime)
 	if err != nil {
+		if writeContextError(c, err) {
+			return
+		}
 		log.Printf("ERROR GetNodeDetailStats: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "Failed to fetch node stats",

--- a/backend/internal/handlers/stats_handlers.go
+++ b/backend/internal/handlers/stats_handlers.go
@@ -64,21 +64,25 @@ func (h *Handlers) GetStatsOverview(c *gin.Context) {
 		}
 		source = "database"
 
-		// Fallback: synthesize from node_pairs when traffic_stats tables are empty
-		if len(buckets) == 0 && len(trafficTypes) == 0 {
-			buckets, err = h.store.GetTrafficStatsFromNodePairs(ctx, startTime, endTime)
+		// Merge derived buckets for unfiltered requests so node_pairs can fill
+		// gaps in traffic_stats without replacing its authoritative values.
+		if len(trafficTypes) == 0 {
+			var derivedBuckets []database.TrafficStats
+			derivedBuckets, err = h.store.GetTrafficStatsFromNodePairs(ctx, startTime, endTime)
 			if err != nil {
 				if writeContextError(c, err) {
 					return
 				}
-				log.Printf("ERROR GetStatsOverview (fallback): %v", err)
+				log.Printf("ERROR GetStatsOverview (derived): %v", err)
 				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": "Failed to fetch derived traffic stats",
+					"error": "Failed to fetch supplemental traffic stats",
 				})
 				return
-			} else {
+			}
+			if len(buckets) == 0 {
 				source = "database (derived)"
 			}
+			buckets = mergeTrafficStatsBuckets(buckets, derivedBuckets)
 		}
 	}
 
@@ -121,6 +125,33 @@ func (h *Handlers) GetStatsOverview(c *gin.Context) {
 			"trafficTypes": trafficTypes,
 		},
 	})
+}
+
+// mergeTrafficStatsBuckets adds derived buckets that are absent from the
+// primary traffic_stats result. Primary buckets always win on overlap.
+func mergeTrafficStatsBuckets(primary, derived []database.TrafficStats) []database.TrafficStats {
+	if len(primary) == 0 && len(derived) == 0 {
+		return nil
+	}
+
+	byBucket := make(map[int64]database.TrafficStats, len(primary)+len(derived))
+	for _, bucket := range primary {
+		byBucket[bucket.Bucket] = bucket
+	}
+	for _, bucket := range derived {
+		if _, exists := byBucket[bucket.Bucket]; !exists {
+			byBucket[bucket.Bucket] = bucket
+		}
+	}
+
+	merged := make([]database.TrafficStats, 0, len(byBucket))
+	for _, bucket := range byBucket {
+		merged = append(merged, bucket)
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		return merged[i].Bucket < merged[j].Bucket
+	})
+	return merged
 }
 
 // GetTopTalkers returns the top N nodes by total traffic

--- a/backend/internal/handlers/stats_handlers.go
+++ b/backend/internal/handlers/stats_handlers.go
@@ -26,7 +26,11 @@ func (h *Handlers) GetStatsOverview(c *gin.Context) {
 
 	var buckets []database.TrafficStats
 	source := "database"
-	trafficTypes := parseBandwidthTrafficTypes(c.Query("trafficTypes"))
+	trafficTypes, trafficTypesErr := parseBandwidthTrafficTypes(c.Query("trafficTypes"))
+	if trafficTypesErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": trafficTypesErr.Error()})
+		return
+	}
 
 	// Try rolling cache first for recent data
 	duration := endTime.Sub(startTime)
@@ -131,7 +135,11 @@ func (h *Handlers) GetTopTalkers(c *gin.Context) {
 	}
 
 	limit := h.parseLimitParam(c, 10, 100)
-	trafficTypes := parseBandwidthTrafficTypes(c.Query("trafficTypes"))
+	trafficTypes, trafficTypesErr := parseBandwidthTrafficTypes(c.Query("trafficTypes"))
+	if trafficTypesErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": trafficTypesErr.Error()})
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), DefaultQueryTimeout)
 	defer cancel()
@@ -235,7 +243,11 @@ func (h *Handlers) GetTopPairs(c *gin.Context) {
 	}
 
 	limit := h.parseLimitParam(c, 10, 100)
-	trafficTypes := parseBandwidthTrafficTypes(c.Query("trafficTypes"))
+	trafficTypes, trafficTypesErr := parseBandwidthTrafficTypes(c.Query("trafficTypes"))
+	if trafficTypesErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": trafficTypesErr.Error()})
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), DefaultQueryTimeout)
 	defer cancel()

--- a/backend/internal/handlers/stats_handlers.go
+++ b/backend/internal/handlers/stats_handlers.go
@@ -186,7 +186,11 @@ func (h *Handlers) GetTopTalkers(c *gin.Context) {
 
 	// Sort by totalBytes descending and cap to requested limit
 	sort.Slice(enriched, func(i, j int) bool {
-		return enriched[i]["totalBytes"].(int64) > enriched[j]["totalBytes"].(int64)
+		left, right := enriched[i]["totalBytes"].(int64), enriched[j]["totalBytes"].(int64)
+		if left != right {
+			return left > right
+		}
+		return enriched[i]["nodeId"].(string) < enriched[j]["nodeId"].(string)
 	})
 	if len(enriched) > limit {
 		enriched = enriched[:limit]
@@ -301,7 +305,14 @@ func (h *Handlers) GetTopPairs(c *gin.Context) {
 
 	// Sort by totalBytes descending and cap to requested limit
 	sort.Slice(enriched, func(i, j int) bool {
-		return enriched[i]["totalBytes"].(int64) > enriched[j]["totalBytes"].(int64)
+		left, right := enriched[i]["totalBytes"].(int64), enriched[j]["totalBytes"].(int64)
+		if left != right {
+			return left > right
+		}
+		if enriched[i]["srcNodeId"].(string) != enriched[j]["srcNodeId"].(string) {
+			return enriched[i]["srcNodeId"].(string) < enriched[j]["srcNodeId"].(string)
+		}
+		return enriched[i]["dstNodeId"].(string) < enriched[j]["dstNodeId"].(string)
 	})
 	if len(enriched) > limit {
 		enriched = enriched[:limit]

--- a/backend/internal/handlers/stats_handlers.go
+++ b/backend/internal/handlers/stats_handlers.go
@@ -32,7 +32,7 @@ func (h *Handlers) GetStatsOverview(c *gin.Context) {
 	duration := endTime.Sub(startTime)
 	if h.poller != nil && duration <= time.Hour && len(trafficTypes) == 0 {
 		cache := h.poller.GetRollingCache()
-		if cache.HasDataFor(startTime, endTime) {
+		if cache.HasTrafficStatsDataFor(startTime, endTime) {
 			buckets = cache.GetTrafficStats(startTime, endTime)
 			source = "cache"
 		}

--- a/backend/internal/services/aggregator.go
+++ b/backend/internal/services/aggregator.go
@@ -319,16 +319,40 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 	for _, agg := range nodePairMap {
 		nodePairs = append(nodePairs, *agg)
 	}
+	sort.Slice(nodePairs, func(i, j int) bool {
+		if nodePairs[i].Bucket != nodePairs[j].Bucket {
+			return nodePairs[i].Bucket < nodePairs[j].Bucket
+		}
+		if nodePairs[i].SrcNodeID != nodePairs[j].SrcNodeID {
+			return nodePairs[i].SrcNodeID < nodePairs[j].SrcNodeID
+		}
+		if nodePairs[i].DstNodeID != nodePairs[j].DstNodeID {
+			return nodePairs[i].DstNodeID < nodePairs[j].DstNodeID
+		}
+		return nodePairs[i].TrafficType < nodePairs[j].TrafficType
+	})
 
 	totalBandwidth := make([]database.BandwidthBucket, 0, len(bandwidthMap))
 	for _, bw := range bandwidthMap {
 		totalBandwidth = append(totalBandwidth, *bw)
 	}
+	sort.Slice(totalBandwidth, func(i, j int) bool {
+		return totalBandwidth[i].Time.Before(totalBandwidth[j].Time)
+	})
 
 	nodeBandwidth := make([]database.NodeBandwidth, 0, len(nodeBwMap))
 	for _, bw := range nodeBwMap {
 		nodeBandwidth = append(nodeBandwidth, *bw)
 	}
+	sort.Slice(nodeBandwidth, func(i, j int) bool {
+		if nodeBandwidth[i].Bucket != nodeBandwidth[j].Bucket {
+			return nodeBandwidth[i].Bucket < nodeBandwidth[j].Bucket
+		}
+		return nodeBandwidth[i].NodeID < nodeBandwidth[j].NodeID
+	})
+	sort.Slice(trafficStats, func(i, j int) bool {
+		return trafficStats[i].Bucket < trafficStats[j].Bucket
+	})
 
 	return nodePairs, totalBandwidth, nodeBandwidth, trafficStats
 }

--- a/backend/internal/services/aggregator.go
+++ b/backend/internal/services/aggregator.go
@@ -8,6 +8,14 @@ import (
 	"github.com/rajsinghtech/tsflow/backend/internal/database"
 )
 
+// trafficPairKey identifies a normalized endpoint pair without encoding the
+// endpoint IDs into a delimiter-joined string. Endpoint IDs are externally
+// sourced and may contain any delimiter.
+type trafficPairKey struct {
+	srcNodeID string
+	dstNodeID string
+}
+
 // aggregate creates pre-computed aggregates from flow logs
 // Handles deduplication: Tailscale logs the same traffic from both endpoints
 // (A->B logged by A, B->A logged by B). We normalize pairs by sorting node IDs
@@ -53,7 +61,7 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 		subnetBytes     int64
 		physicalBytes   int64
 		totalFlows      int64
-		uniquePairs     map[string]struct{} // "nodeA|nodeB" -> exists
+		uniquePairs     map[trafficPairKey]struct{}
 		ports           map[protoPortKey]int64
 	}
 	trafficStatsMap := make(map[int64]*trafficStatsAccum)
@@ -167,7 +175,7 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 		tsAccum, ok := trafficStatsMap[bucket]
 		if !ok {
 			tsAccum = &trafficStatsAccum{
-				uniquePairs: make(map[string]struct{}),
+				uniquePairs: make(map[trafficPairKey]struct{}),
 				ports:       make(map[protoPortKey]int64),
 			}
 			trafficStatsMap[bucket] = tsAccum
@@ -191,7 +199,7 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 			tsAccum.physicalBytes += log.TxBytes
 		}
 		tsAccum.totalFlows++
-		tsAccum.uniquePairs[nodeA+"|"+nodeB] = struct{}{}
+		tsAccum.uniquePairs[trafficPairKey{srcNodeID: nodeA, dstNodeID: nodeB}] = struct{}{}
 		if log.DstPort > 0 {
 			tsAccum.ports[protoPortKey{proto: log.Protocol, port: log.DstPort}] += log.TxBytes
 		}

--- a/backend/internal/services/aggregator.go
+++ b/backend/internal/services/aggregator.go
@@ -45,6 +45,7 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 		udpBytes        int64
 		otherProtoBytes int64
 		virtualBytes    int64
+		exitBytes       int64
 		subnetBytes     int64
 		physicalBytes   int64
 		totalFlows      int64
@@ -164,8 +165,7 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 		case "virtual":
 			tsAccum.virtualBytes += log.TxBytes
 		case "exit":
-			// Exit node traffic flows over the virtual network; count under virtual
-			tsAccum.virtualBytes += log.TxBytes
+			tsAccum.exitBytes += log.TxBytes
 		case "subnet":
 			tsAccum.subnetBytes += log.TxBytes
 		case "physical":
@@ -204,16 +204,20 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 			}
 		}
 
-		// dstNode receives what srcNode transmitted
-		dstBwKey := nodeBwKey{bucket: bucket, nodeID: dstNodeID}
-		if bw, ok := nodeBwMap[dstBwKey]; ok {
-			bw.RxBytes += log.TxBytes // dst receives what src sent
-		} else {
-			nodeBwMap[dstBwKey] = &database.NodeBandwidth{
-				Bucket:  bucket,
-				NodeID:  dstNodeID,
-				TxBytes: 0,
-				RxBytes: log.TxBytes, // dst receives what src sent
+		// A self-flow has one endpoint, so attributing it as both TX and RX would
+		// count the same transmitted bytes twice in per-node totals.
+		if srcNodeID != dstNodeID {
+			// dstNode receives what srcNode transmitted
+			dstBwKey := nodeBwKey{bucket: bucket, nodeID: dstNodeID}
+			if bw, ok := nodeBwMap[dstBwKey]; ok {
+				bw.RxBytes += log.TxBytes // dst receives what src sent
+			} else {
+				nodeBwMap[dstBwKey] = &database.NodeBandwidth{
+					Bucket:  bucket,
+					NodeID:  dstNodeID,
+					TxBytes: 0,
+					RxBytes: log.TxBytes, // dst receives what src sent
+				}
 			}
 		}
 	}
@@ -306,6 +310,7 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 			UDPBytes:        accum.udpBytes,
 			OtherProtoBytes: accum.otherProtoBytes,
 			VirtualBytes:    accum.virtualBytes,
+			ExitBytes:       accum.exitBytes,
 			SubnetBytes:     accum.subnetBytes,
 			PhysicalBytes:   accum.physicalBytes,
 			TotalFlows:      accum.totalFlows,

--- a/backend/internal/services/aggregator.go
+++ b/backend/internal/services/aggregator.go
@@ -34,8 +34,12 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 		port  int
 	}
 	type pairProtoData struct {
-		protocols map[int]int64          // proto number -> total bytes
-		ports     map[protoPortKey]int64 // (proto, port) -> total bytes
+		protocols   map[int]int64          // proto number -> total bytes
+		ports       map[protoPortKey]int64 // (proto, port) -> total bytes
+		txProtocols map[int]int64          // nodeA -> nodeB
+		rxProtocols map[int]int64          // nodeB -> nodeA
+		txPorts     map[protoPortKey]int64 // nodeA -> nodeB
+		rxPorts     map[protoPortKey]int64 // nodeB -> nodeA
 	}
 	pairProtoMap := make(map[nodePairKey]*pairProtoData)
 
@@ -134,14 +138,29 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 		ppData, ok := pairProtoMap[npKey]
 		if !ok {
 			ppData = &pairProtoData{
-				protocols: make(map[int]int64),
-				ports:     make(map[protoPortKey]int64),
+				protocols:   make(map[int]int64),
+				ports:       make(map[protoPortKey]int64),
+				txProtocols: make(map[int]int64),
+				rxProtocols: make(map[int]int64),
+				txPorts:     make(map[protoPortKey]int64),
+				rxPorts:     make(map[protoPortKey]int64),
 			}
 			pairProtoMap[npKey] = ppData
 		}
 		ppData.protocols[log.Protocol] += log.TxBytes
+		if isReverse {
+			ppData.rxProtocols[log.Protocol] += log.TxBytes
+		} else {
+			ppData.txProtocols[log.Protocol] += log.TxBytes
+		}
 		if log.DstPort > 0 {
-			ppData.ports[protoPortKey{proto: log.Protocol, port: log.DstPort}] += log.TxBytes
+			portKey := protoPortKey{proto: log.Protocol, port: log.DstPort}
+			ppData.ports[portKey] += log.TxBytes
+			if isReverse {
+				ppData.rxPorts[portKey] += log.TxBytes
+			} else {
+				ppData.txPorts[portKey] += log.TxBytes
+			}
 		}
 
 		// Accumulate network-wide traffic stats
@@ -245,6 +264,12 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 			if b, err := json.Marshal(ppData.protocols); err == nil {
 				agg.ProtocolBytes = string(b)
 			}
+			if b, err := json.Marshal(ppData.txProtocols); err == nil {
+				agg.TxProtocolBytes = string(b)
+			}
+			if b, err := json.Marshal(ppData.rxProtocols); err == nil {
+				agg.RxProtocolBytes = string(b)
+			}
 
 			// Ports: top 20 by bytes as [{port, proto, bytes}, ...]
 			type portEntry struct {
@@ -271,6 +296,33 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 			if b, err := json.Marshal(portEntries); err == nil {
 				agg.Ports = string(b)
 			}
+
+			serializeDirectionalPorts := func(entries map[protoPortKey]int64) string {
+				portEntries := make([]portEntry, 0, len(entries))
+				for ppk, bytes := range entries {
+					portEntries = append(portEntries, portEntry{Port: ppk.port, Proto: ppk.proto, Bytes: bytes})
+				}
+				sort.Slice(portEntries, func(i, j int) bool {
+					if portEntries[i].Bytes != portEntries[j].Bytes {
+						return portEntries[i].Bytes > portEntries[j].Bytes
+					}
+					if portEntries[i].Proto != portEntries[j].Proto {
+						return portEntries[i].Proto < portEntries[j].Proto
+					}
+					return portEntries[i].Port < portEntries[j].Port
+				})
+				if len(portEntries) > 20 {
+					portEntries = portEntries[:20]
+				}
+				encoded, err := json.Marshal(portEntries)
+				if err != nil {
+					return "[]"
+				}
+				return string(encoded)
+			}
+			agg.TxPorts = serializeDirectionalPorts(ppData.txPorts)
+			agg.RxPorts = serializeDirectionalPorts(ppData.rxPorts)
+			agg.DirectionalPorts = true
 		}
 	}
 

--- a/backend/internal/services/aggregator.go
+++ b/backend/internal/services/aggregator.go
@@ -110,13 +110,14 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 			agg.FlowCount++
 		} else {
 			agg := &database.NodePairAggregate{
-				Bucket:      bucket,
-				SrcNodeID:   nodeA, // nodeA is always "src" in normalized form
-				DstNodeID:   nodeB, // nodeB is always "dst" in normalized form
-				TrafficType: log.TrafficType,
-				FlowCount:   1,
-				Protocols:   "[]",
-				Ports:       "[]",
+				Bucket:        bucket,
+				SrcNodeID:     nodeA, // nodeA is always "src" in normalized form
+				DstNodeID:     nodeB, // nodeB is always "dst" in normalized form
+				TrafficType:   log.TrafficType,
+				FlowCount:     1,
+				Protocols:     "[]",
+				ProtocolBytes: "{}",
+				Ports:         "[]",
 			}
 			if isReverse {
 				agg.RxBytes = log.TxBytes
@@ -220,14 +221,25 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 	// Serialize protocol/port data into node pair aggregates
 	for key, agg := range nodePairMap {
 		if ppData, ok := pairProtoMap[key]; ok {
-			// Protocols: sorted list of unique protocol numbers
+			// Protocols: most-byte-heavy first, with protocol number as a
+			// deterministic tie-breaker. Consumers use the first item as the
+			// dominant protocol.
 			protos := make([]int, 0, len(ppData.protocols))
 			for p := range ppData.protocols {
 				protos = append(protos, p)
 			}
-			sort.Ints(protos)
+			sort.Slice(protos, func(i, j int) bool {
+				left, right := ppData.protocols[protos[i]], ppData.protocols[protos[j]]
+				if left != right {
+					return left > right
+				}
+				return protos[i] < protos[j]
+			})
 			if b, err := json.Marshal(protos); err == nil {
 				agg.Protocols = string(b)
+			}
+			if b, err := json.Marshal(ppData.protocols); err == nil {
+				agg.ProtocolBytes = string(b)
 			}
 
 			// Ports: top 20 by bytes as [{port, proto, bytes}, ...]
@@ -241,7 +253,13 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 				portEntries = append(portEntries, portEntry{Port: ppk.port, Proto: ppk.proto, Bytes: bytes})
 			}
 			sort.Slice(portEntries, func(i, j int) bool {
-				return portEntries[i].Bytes > portEntries[j].Bytes
+				if portEntries[i].Bytes != portEntries[j].Bytes {
+					return portEntries[i].Bytes > portEntries[j].Bytes
+				}
+				if portEntries[i].Proto != portEntries[j].Proto {
+					return portEntries[i].Proto < portEntries[j].Proto
+				}
+				return portEntries[i].Port < portEntries[j].Port
 			})
 			if len(portEntries) > 20 {
 				portEntries = portEntries[:20]
@@ -266,7 +284,13 @@ func (p *Poller) aggregate(logs []database.FlowLog) (
 			portEntries = append(portEntries, portEntry{Port: ppk.port, Proto: ppk.proto, Bytes: bytes})
 		}
 		sort.Slice(portEntries, func(i, j int) bool {
-			return portEntries[i].Bytes > portEntries[j].Bytes
+			if portEntries[i].Bytes != portEntries[j].Bytes {
+				return portEntries[i].Bytes > portEntries[j].Bytes
+			}
+			if portEntries[i].Proto != portEntries[j].Proto {
+				return portEntries[i].Proto < portEntries[j].Proto
+			}
+			return portEntries[i].Port < portEntries[j].Port
 		})
 		if len(portEntries) > 20 {
 			portEntries = portEntries[:20]

--- a/backend/internal/services/aggregator_test.go
+++ b/backend/internal/services/aggregator_test.go
@@ -169,3 +169,20 @@ func TestAggregateSelfTrafficDoesNotDoubleCountPerNodeBandwidth(t *testing.T) {
 		t.Fatalf("self pair = %+v, want TX 7 RX 0 and one flow", selfPair)
 	}
 }
+
+func TestAggregateTrafficStatsDistinguishDelimiterContainingPairs(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	base := time.Now().UTC().Truncate(time.Minute)
+	logs := []database.FlowLog{
+		{LoggedAt: base.Add(5 * time.Second), SrcIP: "a|b", DstIP: "c", TrafficType: "virtual", Protocol: 6, TxBytes: 100},
+		{LoggedAt: base.Add(10 * time.Second), SrcIP: "a", DstIP: "b|c", TrafficType: "virtual", Protocol: 17, TxBytes: 200},
+	}
+
+	pairs, _, _, stats := poller.aggregate(logs)
+	if len(pairs) != 2 || len(stats) != 1 {
+		t.Fatalf("aggregate sizes = pairs %d, stats %d; want 2 and 1", len(pairs), len(stats))
+	}
+	if stats[0].TCPBytes != 100 || stats[0].UDPBytes != 200 || stats[0].TotalFlows != 2 || stats[0].UniquePairs != 2 {
+		t.Fatalf("traffic stats = %+v, want separate delimiter-containing pairs", stats[0])
+	}
+}

--- a/backend/internal/services/aggregator_test.go
+++ b/backend/internal/services/aggregator_test.go
@@ -73,3 +73,50 @@ func TestAggregateCapsTopPortsAtTwenty(t *testing.T) {
 		}
 	}
 }
+
+func TestAggregateSelfTrafficDoesNotDoubleCountPerNodeBandwidth(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	base := time.Now().UTC().Truncate(time.Minute)
+	logs := []database.FlowLog{
+		{LoggedAt: base.Add(5 * time.Second), SrcIP: "100.64.0.1", DstIP: "100.64.0.2", TrafficType: "virtual", Protocol: 6, TxBytes: 100},
+		{LoggedAt: base.Add(10 * time.Second), SrcIP: "100.64.0.2", DstIP: "100.64.0.1", TrafficType: "virtual", Protocol: 6, TxBytes: 40},
+		{LoggedAt: base.Add(15 * time.Second), SrcIP: "100.64.0.3", DstIP: "100.64.0.3", TrafficType: "virtual", Protocol: 6, TxBytes: 7},
+	}
+
+	pairs, bandwidth, nodeBandwidth, stats := poller.aggregate(logs)
+	if len(pairs) != 2 || len(bandwidth) != 1 || len(nodeBandwidth) != 3 || len(stats) != 1 {
+		t.Fatalf("aggregate sizes = pairs %d, bandwidth %d, node bandwidth %d, stats %d; want 2, 1, 3, 1", len(pairs), len(bandwidth), len(nodeBandwidth), len(stats))
+	}
+
+	if bandwidth[0].TxBytes != 147 || bandwidth[0].RxBytes != 0 {
+		t.Fatalf("total bandwidth = %+v, want TX 147 and RX 0", bandwidth[0])
+	}
+	if stats[0].TCPBytes != 147 || stats[0].TotalFlows != 3 || stats[0].UniquePairs != 2 {
+		t.Fatalf("traffic stats = %+v, want TCP 147, three flows, two pairs", stats[0])
+	}
+
+	nodeTotals := make(map[string]database.NodeBandwidth, len(nodeBandwidth))
+	for _, node := range nodeBandwidth {
+		nodeTotals[node.NodeID] = node
+	}
+	if got := nodeTotals["100.64.0.1"]; got.TxBytes != 100 || got.RxBytes != 40 {
+		t.Fatalf("node 100.64.0.1 bandwidth = %+v, want TX 100 RX 40", got)
+	}
+	if got := nodeTotals["100.64.0.2"]; got.TxBytes != 40 || got.RxBytes != 100 {
+		t.Fatalf("node 100.64.0.2 bandwidth = %+v, want TX 40 RX 100", got)
+	}
+	if got := nodeTotals["100.64.0.3"]; got.TxBytes != 7 || got.RxBytes != 0 {
+		t.Fatalf("self node bandwidth = %+v, want TX 7 RX 0", got)
+	}
+
+	var selfPair *database.NodePairAggregate
+	for i := range pairs {
+		if pairs[i].SrcNodeID == "100.64.0.3" {
+			selfPair = &pairs[i]
+			break
+		}
+	}
+	if selfPair == nil || selfPair.TxBytes != 7 || selfPair.RxBytes != 0 || selfPair.FlowCount != 1 {
+		t.Fatalf("self pair = %+v, want TX 7 RX 0 and one flow", selfPair)
+	}
+}

--- a/backend/internal/services/aggregator_test.go
+++ b/backend/internal/services/aggregator_test.go
@@ -1,0 +1,75 @@
+package services
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rajsinghtech/tsflow/backend/internal/database"
+)
+
+func TestAggregateOrdersProtocolsByBytesAndPortsDeterministically(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	base := time.Now().UTC().Truncate(time.Minute)
+	logs := []database.FlowLog{
+		{LoggedAt: base.Add(5 * time.Second), SrcIP: "100.64.0.1", DstIP: "100.64.0.2", TrafficType: "virtual", Protocol: 6, DstPort: 443, TxBytes: 100},
+		{LoggedAt: base.Add(10 * time.Second), SrcIP: "100.64.0.1", DstIP: "100.64.0.2", TrafficType: "virtual", Protocol: 17, DstPort: 53, TxBytes: 300},
+		{LoggedAt: base.Add(15 * time.Second), SrcIP: "100.64.0.1", DstIP: "100.64.0.2", TrafficType: "virtual", Protocol: 6, DstPort: 80, TxBytes: 200},
+	}
+
+	nodePairs, _, _, trafficStats := poller.aggregate(logs)
+	if len(nodePairs) != 1 || len(trafficStats) != 1 {
+		t.Fatalf("expected one pair and one stats bucket, got %d and %d", len(nodePairs), len(trafficStats))
+	}
+
+	var protocols []int
+	if err := json.Unmarshal([]byte(nodePairs[0].Protocols), &protocols); err != nil {
+		t.Fatal(err)
+	}
+	if len(protocols) != 2 || protocols[0] != 6 || protocols[1] != 17 {
+		t.Fatalf("protocol order = %v, want [6 17]", protocols)
+	}
+	var protocolBytes map[string]int64
+	if err := json.Unmarshal([]byte(nodePairs[0].ProtocolBytes), &protocolBytes); err != nil {
+		t.Fatal(err)
+	}
+	if protocolBytes["6"] != 300 || protocolBytes["17"] != 300 {
+		t.Fatalf("protocol byte totals = %v", protocolBytes)
+	}
+
+	var ports []database.PortStat
+	if err := json.Unmarshal([]byte(nodePairs[0].Ports), &ports); err != nil {
+		t.Fatal(err)
+	}
+	if len(ports) != 3 || ports[0].Port != 53 || ports[1].Port != 80 || ports[2].Port != 443 {
+		t.Fatalf("ports = %+v", ports)
+	}
+}
+
+func TestAggregateCapsTopPortsAtTwenty(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	base := time.Now().UTC().Truncate(time.Minute)
+	logs := make([]database.FlowLog, 0, 25)
+	for port := 1; port <= 25; port++ {
+		logs = append(logs, database.FlowLog{
+			LoggedAt: base.Add(time.Duration(port) * time.Second), SrcIP: "100.64.0.1", DstIP: "100.64.0.2",
+			TrafficType: "virtual", Protocol: 6, DstPort: port, TxBytes: int64(port),
+		})
+	}
+	nodePairs, _, _, trafficStats := poller.aggregate(logs)
+	if len(nodePairs) != 1 || len(trafficStats) != 1 {
+		t.Fatalf("expected one pair and stats bucket")
+	}
+	for _, raw := range []string{nodePairs[0].Ports, trafficStats[0].TopPorts} {
+		var ports []database.PortStat
+		if err := json.Unmarshal([]byte(raw), &ports); err != nil {
+			t.Fatal(err)
+		}
+		if len(ports) != 20 {
+			t.Fatalf("expected 20 ports, got %d", len(ports))
+		}
+		if ports[0].Port != 25 || ports[19].Port != 6 {
+			t.Fatalf("ports not deterministically ranked: first=%+v last=%+v", ports[0], ports[19])
+		}
+	}
+}

--- a/backend/internal/services/aggregator_test.go
+++ b/backend/internal/services/aggregator_test.go
@@ -46,6 +46,55 @@ func TestAggregateOrdersProtocolsByBytesAndPortsDeterministically(t *testing.T) 
 	}
 }
 
+func TestAggregatePreservesDirectionalProtocolAndPortOrientation(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	base := time.Now().UTC().Truncate(time.Minute)
+	logs := []database.FlowLog{
+		{LoggedAt: base.Add(5 * time.Second), SrcIP: "100.64.0.1", DstIP: "100.64.0.2", TrafficType: "virtual", Protocol: 6, DstPort: 443, TxBytes: 100},
+		{LoggedAt: base.Add(10 * time.Second), SrcIP: "100.64.0.2", DstIP: "100.64.0.1", TrafficType: "virtual", Protocol: 17, DstPort: 53, TxBytes: 40},
+	}
+
+	pairs, _, _, _ := poller.aggregate(logs)
+	if len(pairs) != 1 {
+		t.Fatalf("expected one normalized pair, got %d", len(pairs))
+	}
+	pair := pairs[0]
+	if pair.SrcNodeID != "100.64.0.1" || pair.DstNodeID != "100.64.0.2" {
+		t.Fatalf("normalized pair = %s -> %s", pair.SrcNodeID, pair.DstNodeID)
+	}
+	if pair.TxBytes != 100 || pair.RxBytes != 40 || !pair.DirectionalPorts {
+		t.Fatalf("directional totals = %+v", pair)
+	}
+
+	var txProtocols, rxProtocols map[string]int64
+	if err := json.Unmarshal([]byte(pair.TxProtocolBytes), &txProtocols); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(pair.RxProtocolBytes), &rxProtocols); err != nil {
+		t.Fatal(err)
+	}
+	if txProtocols["6"] != 100 || len(txProtocols) != 1 {
+		t.Fatalf("forward protocols = %+v", txProtocols)
+	}
+	if rxProtocols["17"] != 40 || len(rxProtocols) != 1 {
+		t.Fatalf("reverse protocols = %+v", rxProtocols)
+	}
+
+	var txPorts, rxPorts []database.PortStat
+	if err := json.Unmarshal([]byte(pair.TxPorts), &txPorts); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(pair.RxPorts), &rxPorts); err != nil {
+		t.Fatal(err)
+	}
+	if len(txPorts) != 1 || txPorts[0].Port != 443 || txPorts[0].Proto != 6 {
+		t.Fatalf("forward ports = %+v", txPorts)
+	}
+	if len(rxPorts) != 1 || rxPorts[0].Port != 53 || rxPorts[0].Proto != 17 {
+		t.Fatalf("reverse ports = %+v", rxPorts)
+	}
+}
+
 func TestAggregateCapsTopPortsAtTwenty(t *testing.T) {
 	poller := NewPoller(nil, nil, DefaultPollerConfig())
 	base := time.Now().UTC().Truncate(time.Minute)

--- a/backend/internal/services/log_converter.go
+++ b/backend/internal/services/log_converter.go
@@ -56,6 +56,10 @@ func (p *Poller) convertTailscaleLog(tsLog tailscale.NetworkFlowLog) []database.
 	if logTime.IsZero() {
 		logTime = tsLog.Logged // fallback if Start not populated
 	}
+	if logTime.IsZero() {
+		log.Printf("Warning: skipping flow log with no start or logged timestamp for node %s", tsLog.NodeID)
+		return flowLogs
+	}
 
 	// Process virtual traffic
 	for _, traffic := range tsLog.VirtualTraffic {

--- a/backend/internal/services/log_converter.go
+++ b/backend/internal/services/log_converter.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"log"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -187,53 +189,68 @@ func (p *Poller) convertMapLog(logMap map[string]any) []database.FlowLog {
 
 // Helper functions
 func extractIP(addr string) string {
-	// Handle IPv6 with brackets: [::1]:443
-	if strings.HasPrefix(addr, "[") {
-		end := strings.Index(addr, "]")
-		if end > 0 {
-			return addr[1:end]
-		}
-	}
-	// Handle IPv4: 192.168.1.1:443
-	if idx := strings.LastIndex(addr, ":"); idx > 0 {
-		return addr[:idx]
+	host, _, ok := splitEndpoint(addr)
+	if ok {
+		return host
 	}
 	return addr
 }
 
 func extractPort(addr string) int {
-	// Handle IPv6 with brackets: [::1]:443
-	if strings.HasPrefix(addr, "[") {
-		end := strings.Index(addr, "]:")
-		if end > 0 {
-			var port int
-			_, _ = parsePort(addr[end+2:], &port)
-			return port
-		}
+	_, port, ok := splitEndpoint(addr)
+	if !ok {
 		return 0
 	}
-	// Handle IPv4: 192.168.1.1:443
-	if idx := strings.LastIndex(addr, ":"); idx > 0 {
-		var port int
-		_, _ = parsePort(addr[idx+1:], &port)
-		return port
-	}
-	return 0
+	return port
 }
 
-func parsePort(s string, port *int) (bool, error) {
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return false, nil
-		}
-		*port = *port*10 + int(c-'0')
-		// Prevent overflow and validate port range
-		if *port > 65535 {
-			*port = 0
-			return false, nil
-		}
+// splitEndpoint separates an address from an optional port without treating
+// an unbracketed IPv6 address as host:port. Tailscale normally emits
+// bracketed IPv6 endpoints when a port is present, but exported logs can also
+// contain bare IPs and opaque node/host identifiers.
+func splitEndpoint(addr string) (host string, port int, ok bool) {
+	if addr == "" {
+		return "", 0, false
 	}
-	return *port > 0 && *port <= 65535, nil
+
+	// A complete IP address is never interpreted as having a port. This is
+	// essential for IPv6, where the final colon-separated segment is not a
+	// port delimiter unless the address is bracketed.
+	if net.ParseIP(addr) != nil {
+		return addr, 0, true
+	}
+
+	if strings.HasPrefix(addr, "[") {
+		end := strings.IndexByte(addr, ']')
+		if end <= 1 || net.ParseIP(addr[1:end]) == nil {
+			return "", 0, false
+		}
+		host = addr[1:end]
+		suffix := addr[end+1:]
+		if suffix == "" {
+			return host, 0, true
+		}
+		if !strings.HasPrefix(suffix, ":") {
+			return "", 0, false
+		}
+		return host, validPort(suffix[1:]), true
+	}
+
+	// SplitHostPort handles IPv4 and host names. It rejects bare IPv6, which
+	// was already handled above by ParseIP.
+	host, portText, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, false
+	}
+	return host, validPort(portText), true
+}
+
+func validPort(raw string) int {
+	port, err := strconv.Atoi(raw)
+	if err != nil || port <= 0 || port > 65535 {
+		return 0
+	}
+	return port
 }
 
 func getString(m map[string]any, key string) string {

--- a/backend/internal/services/log_converter.go
+++ b/backend/internal/services/log_converter.go
@@ -59,14 +59,18 @@ func (p *Poller) convertTailscaleLog(tsLog tailscale.NetworkFlowLog) []database.
 
 	// Process virtual traffic
 	for _, traffic := range tsLog.VirtualTraffic {
+		srcIP, dstIP, ok := flowEndpoints(traffic.Src, traffic.Dst)
+		if !ok {
+			continue
+		}
 		flowLogs = append(flowLogs, database.FlowLog{
 			LoggedAt:    logTime,
 			NodeID:      tsLog.NodeID,
 			TrafficType: "virtual",
 			Protocol:    traffic.Proto,
-			SrcIP:       extractIP(traffic.Src),
+			SrcIP:       srcIP,
 			SrcPort:     extractPort(traffic.Src),
-			DstIP:       extractIP(traffic.Dst),
+			DstIP:       dstIP,
 			DstPort:     extractPort(traffic.Dst),
 			TxBytes:     int64(traffic.TxBytes),
 			RxBytes:     int64(traffic.RxBytes),
@@ -77,14 +81,18 @@ func (p *Poller) convertTailscaleLog(tsLog tailscale.NetworkFlowLog) []database.
 
 	// Process subnet traffic
 	for _, traffic := range tsLog.SubnetTraffic {
+		srcIP, dstIP, ok := flowEndpoints(traffic.Src, traffic.Dst)
+		if !ok {
+			continue
+		}
 		flowLogs = append(flowLogs, database.FlowLog{
 			LoggedAt:    logTime,
 			NodeID:      tsLog.NodeID,
 			TrafficType: "subnet",
 			Protocol:    traffic.Proto,
-			SrcIP:       extractIP(traffic.Src),
+			SrcIP:       srcIP,
 			SrcPort:     extractPort(traffic.Src),
-			DstIP:       extractIP(traffic.Dst),
+			DstIP:       dstIP,
 			DstPort:     extractPort(traffic.Dst),
 			TxBytes:     int64(traffic.TxBytes),
 			RxBytes:     int64(traffic.RxBytes),
@@ -95,14 +103,18 @@ func (p *Poller) convertTailscaleLog(tsLog tailscale.NetworkFlowLog) []database.
 
 	// Process exit traffic (traffic via exit nodes)
 	for _, traffic := range tsLog.ExitTraffic {
+		srcIP, dstIP, ok := flowEndpoints(traffic.Src, traffic.Dst)
+		if !ok {
+			continue
+		}
 		flowLogs = append(flowLogs, database.FlowLog{
 			LoggedAt:    logTime,
 			NodeID:      tsLog.NodeID,
 			TrafficType: "exit",
 			Protocol:    traffic.Proto,
-			SrcIP:       extractIP(traffic.Src),
+			SrcIP:       srcIP,
 			SrcPort:     extractPort(traffic.Src),
-			DstIP:       extractIP(traffic.Dst),
+			DstIP:       dstIP,
 			DstPort:     extractPort(traffic.Dst),
 			TxBytes:     int64(traffic.TxBytes),
 			RxBytes:     int64(traffic.RxBytes),
@@ -113,14 +125,18 @@ func (p *Poller) convertTailscaleLog(tsLog tailscale.NetworkFlowLog) []database.
 
 	// Process physical traffic
 	for _, traffic := range tsLog.PhysicalTraffic {
+		srcIP, dstIP, ok := flowEndpoints(traffic.Src, traffic.Dst)
+		if !ok {
+			continue
+		}
 		flowLogs = append(flowLogs, database.FlowLog{
 			LoggedAt:    logTime,
 			NodeID:      tsLog.NodeID,
 			TrafficType: "physical",
 			Protocol:    traffic.Proto,
-			SrcIP:       extractIP(traffic.Src),
+			SrcIP:       srcIP,
 			SrcPort:     extractPort(traffic.Src),
-			DstIP:       extractIP(traffic.Dst),
+			DstIP:       dstIP,
 			DstPort:     extractPort(traffic.Dst),
 			TxBytes:     int64(traffic.TxBytes),
 			RxBytes:     0,
@@ -158,6 +174,10 @@ func (p *Poller) convertMapLog(logMap map[string]any) []database.FlowLog {
 			isPhysical := typeName == "physical"
 			for _, t := range traffic {
 				if tMap, ok := t.(map[string]any); ok {
+					srcIP, dstIP, endpointOK := flowEndpoints(getString(tMap, "src"), getString(tMap, "dst"))
+					if !endpointOK {
+						continue
+					}
 					rxBytes := getInt64(tMap, "rxBytes")
 					rxPkts := getInt64(tMap, "rxPkts")
 					// Physical traffic has no RX data in the Tailscale API
@@ -170,9 +190,9 @@ func (p *Poller) convertMapLog(logMap map[string]any) []database.FlowLog {
 						NodeID:      nodeID,
 						TrafficType: typeName,
 						Protocol:    getInt(tMap, "proto"),
-						SrcIP:       extractIP(getString(tMap, "src")),
+						SrcIP:       srcIP,
 						SrcPort:     extractPort(getString(tMap, "src")),
-						DstIP:       extractIP(getString(tMap, "dst")),
+						DstIP:       dstIP,
 						DstPort:     extractPort(getString(tMap, "dst")),
 						TxBytes:     getInt64(tMap, "txBytes"),
 						RxBytes:     rxBytes,
@@ -202,6 +222,12 @@ func extractPort(addr string) int {
 		return 0
 	}
 	return port
+}
+
+func flowEndpoints(src, dst string) (string, string, bool) {
+	srcIP := strings.TrimSpace(extractIP(src))
+	dstIP := strings.TrimSpace(extractIP(dst))
+	return srcIP, dstIP, srcIP != "" && dstIP != ""
 }
 
 // splitEndpoint separates an address from an optional port without treating

--- a/backend/internal/services/log_converter.go
+++ b/backend/internal/services/log_converter.go
@@ -1,7 +1,9 @@
 package services
 
 import (
+	"encoding/json"
 	"log"
+	"math"
 	"net"
 	"strconv"
 	"strings"
@@ -61,92 +63,43 @@ func (p *Poller) convertTailscaleLog(tsLog tailscale.NetworkFlowLog) []database.
 		return flowLogs
 	}
 
-	// Process virtual traffic
+	appendTraffic := func(traffic tailscale.TrafficStats, trafficType string, includeRx bool) {
+		srcIP, dstIP, ok := flowEndpoints(traffic.Src, traffic.Dst)
+		if !ok {
+			return
+		}
+		txBytes, rxBytes, txPkts, rxPkts, ok := convertTypedCounters(traffic, includeRx)
+		if !ok {
+			log.Printf("Warning: skipping flow log with out-of-range counters for node %s", tsLog.NodeID)
+			return
+		}
+		flowLogs = append(flowLogs, database.FlowLog{
+			LoggedAt:    logTime,
+			NodeID:      tsLog.NodeID,
+			TrafficType: trafficType,
+			Protocol:    traffic.Proto,
+			SrcIP:       srcIP,
+			SrcPort:     extractPort(traffic.Src),
+			DstIP:       dstIP,
+			DstPort:     extractPort(traffic.Dst),
+			TxBytes:     txBytes,
+			RxBytes:     rxBytes,
+			TxPkts:      txPkts,
+			RxPkts:      rxPkts,
+		})
+	}
+
 	for _, traffic := range tsLog.VirtualTraffic {
-		srcIP, dstIP, ok := flowEndpoints(traffic.Src, traffic.Dst)
-		if !ok {
-			continue
-		}
-		flowLogs = append(flowLogs, database.FlowLog{
-			LoggedAt:    logTime,
-			NodeID:      tsLog.NodeID,
-			TrafficType: "virtual",
-			Protocol:    traffic.Proto,
-			SrcIP:       srcIP,
-			SrcPort:     extractPort(traffic.Src),
-			DstIP:       dstIP,
-			DstPort:     extractPort(traffic.Dst),
-			TxBytes:     int64(traffic.TxBytes),
-			RxBytes:     int64(traffic.RxBytes),
-			TxPkts:      int64(traffic.TxPkts),
-			RxPkts:      int64(traffic.RxPkts),
-		})
+		appendTraffic(traffic, "virtual", true)
 	}
-
-	// Process subnet traffic
 	for _, traffic := range tsLog.SubnetTraffic {
-		srcIP, dstIP, ok := flowEndpoints(traffic.Src, traffic.Dst)
-		if !ok {
-			continue
-		}
-		flowLogs = append(flowLogs, database.FlowLog{
-			LoggedAt:    logTime,
-			NodeID:      tsLog.NodeID,
-			TrafficType: "subnet",
-			Protocol:    traffic.Proto,
-			SrcIP:       srcIP,
-			SrcPort:     extractPort(traffic.Src),
-			DstIP:       dstIP,
-			DstPort:     extractPort(traffic.Dst),
-			TxBytes:     int64(traffic.TxBytes),
-			RxBytes:     int64(traffic.RxBytes),
-			TxPkts:      int64(traffic.TxPkts),
-			RxPkts:      int64(traffic.RxPkts),
-		})
+		appendTraffic(traffic, "subnet", true)
 	}
-
-	// Process exit traffic (traffic via exit nodes)
 	for _, traffic := range tsLog.ExitTraffic {
-		srcIP, dstIP, ok := flowEndpoints(traffic.Src, traffic.Dst)
-		if !ok {
-			continue
-		}
-		flowLogs = append(flowLogs, database.FlowLog{
-			LoggedAt:    logTime,
-			NodeID:      tsLog.NodeID,
-			TrafficType: "exit",
-			Protocol:    traffic.Proto,
-			SrcIP:       srcIP,
-			SrcPort:     extractPort(traffic.Src),
-			DstIP:       dstIP,
-			DstPort:     extractPort(traffic.Dst),
-			TxBytes:     int64(traffic.TxBytes),
-			RxBytes:     int64(traffic.RxBytes),
-			TxPkts:      int64(traffic.TxPkts),
-			RxPkts:      int64(traffic.RxPkts),
-		})
+		appendTraffic(traffic, "exit", true)
 	}
-
-	// Process physical traffic
 	for _, traffic := range tsLog.PhysicalTraffic {
-		srcIP, dstIP, ok := flowEndpoints(traffic.Src, traffic.Dst)
-		if !ok {
-			continue
-		}
-		flowLogs = append(flowLogs, database.FlowLog{
-			LoggedAt:    logTime,
-			NodeID:      tsLog.NodeID,
-			TrafficType: "physical",
-			Protocol:    traffic.Proto,
-			SrcIP:       srcIP,
-			SrcPort:     extractPort(traffic.Src),
-			DstIP:       dstIP,
-			DstPort:     extractPort(traffic.Dst),
-			TxBytes:     int64(traffic.TxBytes),
-			RxBytes:     0,
-			TxPkts:      int64(traffic.TxPkts),
-			RxPkts:      0,
-		})
+		appendTraffic(traffic, "physical", false)
 	}
 
 	return flowLogs
@@ -182,8 +135,14 @@ func (p *Poller) convertMapLog(logMap map[string]any) []database.FlowLog {
 					if !endpointOK {
 						continue
 					}
-					rxBytes := getInt64(tMap, "rxBytes")
-					rxPkts := getInt64(tMap, "rxPkts")
+					txBytes, txBytesOK := getCounter(tMap, "txBytes")
+					rxBytes, rxBytesOK := getCounter(tMap, "rxBytes")
+					txPkts, txPktsOK := getCounter(tMap, "txPkts")
+					rxPkts, rxPktsOK := getCounter(tMap, "rxPkts")
+					if !txBytesOK || !txPktsOK || (!isPhysical && (!rxBytesOK || !rxPktsOK)) {
+						log.Printf("Warning: skipping flow log with invalid counters for node %s", nodeID)
+						continue
+					}
 					// Physical traffic has no RX data in the Tailscale API
 					if isPhysical {
 						rxBytes = 0
@@ -198,9 +157,9 @@ func (p *Poller) convertMapLog(logMap map[string]any) []database.FlowLog {
 						SrcPort:     extractPort(getString(tMap, "src")),
 						DstIP:       dstIP,
 						DstPort:     extractPort(getString(tMap, "dst")),
-						TxBytes:     getInt64(tMap, "txBytes"),
+						TxBytes:     txBytes,
 						RxBytes:     rxBytes,
-						TxPkts:      getInt64(tMap, "txPkts"),
+						TxPkts:      txPkts,
 						RxPkts:      rxPkts,
 					})
 				}
@@ -291,26 +250,77 @@ func getString(m map[string]any, key string) string {
 }
 
 func getInt(m map[string]any, key string) int {
-	if v, ok := m[key].(float64); ok {
-		// Validate float is within int range and not NaN/Inf
-		if v != v || v > float64(int(^uint(0)>>1)) || v < float64(-int(^uint(0)>>1)-1) {
-			return 0
-		}
-		return int(v)
+	value, ok := parseInt64(m[key])
+	if !ok || value > int64(^uint(0)>>1) || value < -int64(^uint(0)>>1)-1 {
+		return 0
 	}
-	return 0
+	return int(value)
 }
 
-func getInt64(m map[string]any, key string) int64 {
-	if v, ok := m[key].(float64); ok {
-		// Validate float is within int64 range and not NaN/Inf
-		// Note: float64 can't exactly represent all int64 values, but this catches major issues
-		if v != v || v > float64(1<<63-1) || v < float64(-1<<63) {
-			return 0
-		}
-		return int64(v)
+func getCounter(m map[string]any, key string) (int64, bool) {
+	raw, exists := m[key]
+	if !exists || raw == nil {
+		return 0, true
 	}
-	return 0
+	return parseInt64(raw)
+}
+
+func parseInt64(raw any) (int64, bool) {
+	switch v := raw.(type) {
+	case float64:
+		// JSON numbers are decoded as float64. Reject fractional, NaN/Inf, and
+		// negative values and values at or above 2^63, which float64 rounds
+		// MaxInt64 up to. Traffic counters are unsigned in the API.
+		if math.IsNaN(v) || math.IsInf(v, 0) || v != math.Trunc(v) || v < 0 || v >= float64(1<<63) {
+			return 0, false
+		}
+		return int64(v), true
+	case float32:
+		return parseInt64(float64(v))
+	case json.Number:
+		value, err := v.Int64()
+		return value, err == nil && value >= 0
+	case int:
+		return int64(v), v >= 0
+	case int64:
+		return v, v >= 0
+	case uint:
+		return uint64ToInt64(uint64(v))
+	case uint64:
+		return uint64ToInt64(v)
+	default:
+		return 0, false
+	}
+}
+
+func uint64ToInt64(value uint64) (int64, bool) {
+	if value > uint64(^uint64(0)>>1) {
+		return 0, false
+	}
+	return int64(value), true
+}
+
+func convertTypedCounters(traffic tailscale.TrafficStats, includeRx bool) (int64, int64, int64, int64, bool) {
+	txBytes, ok := uint64ToInt64(traffic.TxBytes)
+	if !ok {
+		return 0, 0, 0, 0, false
+	}
+	txPkts, ok := uint64ToInt64(traffic.TxPkts)
+	if !ok {
+		return 0, 0, 0, 0, false
+	}
+	if !includeRx {
+		return txBytes, 0, txPkts, 0, true
+	}
+	rxBytes, ok := uint64ToInt64(traffic.RxBytes)
+	if !ok {
+		return 0, 0, 0, 0, false
+	}
+	rxPkts, ok := uint64ToInt64(traffic.RxPkts)
+	if !ok {
+		return 0, 0, 0, 0, false
+	}
+	return txBytes, rxBytes, txPkts, rxPkts, true
 }
 
 func mapKeys(m map[string]any) []string {

--- a/backend/internal/services/log_converter_test.go
+++ b/backend/internal/services/log_converter_test.go
@@ -99,3 +99,19 @@ func TestConvertTailscaleLogSkipsRowsWithMissingEndpoints(t *testing.T) {
 		t.Fatalf("converted %d flows, want one valid flow", len(flows))
 	}
 }
+
+func TestConvertTailscaleLogSkipsRowsWithMissingTimestamp(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	flows := poller.convertTailscaleLog(tailscale.NetworkFlowLog{
+		NodeID: "node-a",
+		VirtualTraffic: []tailscale.TrafficStats{{
+			Proto:   6,
+			Src:     "100.64.0.1:1234",
+			Dst:     "100.64.0.2:443",
+			TxBytes: 10,
+		}},
+	})
+	if len(flows) != 0 {
+		t.Fatalf("converted %d flows with no timestamp, want none", len(flows))
+	}
+}

--- a/backend/internal/services/log_converter_test.go
+++ b/backend/internal/services/log_converter_test.go
@@ -1,6 +1,11 @@
 package services
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	tailscale "tailscale.com/client/tailscale/v2"
+)
 
 func TestExtractEndpointHandlesIPv4AndIPv6(t *testing.T) {
 	tests := []struct {
@@ -48,5 +53,49 @@ func TestExtractEndpointRejectsMalformedPortsWithoutTruncatingHosts(t *testing.T
 				t.Fatalf("extractPort(%q) = %d, want 0", tt.addr, got)
 			}
 		})
+	}
+}
+
+func TestConvertMapLogSkipsRowsWithMissingEndpoints(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	logMap := map[string]any{
+		"nodeId": "node-a",
+		"start":  "2026-05-08T13:45:00Z",
+		"virtualTraffic": []any{
+			map[string]any{
+				"proto":   float64(6),
+				"src":     "",
+				"dst":     "100.64.0.2:443",
+				"txBytes": float64(10),
+			},
+			map[string]any{
+				"proto":   float64(6),
+				"src":     "100.64.0.1:1234",
+				"dst":     "100.64.0.2:443",
+				"txBytes": float64(20),
+			},
+		},
+	}
+
+	flows := poller.convertMapLog(logMap)
+	if len(flows) != 1 {
+		t.Fatalf("converted %d flows, want one valid flow", len(flows))
+	}
+	if flows[0].SrcIP == "" || flows[0].DstIP == "" {
+		t.Fatalf("converted flow contains blank endpoint: %+v", flows[0])
+	}
+}
+
+func TestConvertTailscaleLogSkipsRowsWithMissingEndpoints(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	flows := poller.convertTailscaleLog(tailscale.NetworkFlowLog{
+		Start: time.Date(2026, 5, 8, 13, 45, 0, 0, time.UTC),
+		VirtualTraffic: []tailscale.TrafficStats{
+			{Proto: 6, Dst: "100.64.0.2:443", TxBytes: 10},
+			{Proto: 6, Src: "100.64.0.1:1234", Dst: "100.64.0.2:443", TxBytes: 20},
+		},
+	})
+	if len(flows) != 1 {
+		t.Fatalf("converted %d flows, want one valid flow", len(flows))
 	}
 }

--- a/backend/internal/services/log_converter_test.go
+++ b/backend/internal/services/log_converter_test.go
@@ -115,3 +115,51 @@ func TestConvertTailscaleLogSkipsRowsWithMissingTimestamp(t *testing.T) {
 		t.Fatalf("converted %d flows with no timestamp, want none", len(flows))
 	}
 }
+
+func TestConvertTailscaleLogSkipsCountersThatDoNotFitSQLiteIntegers(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	flows := poller.convertTailscaleLog(tailscale.NetworkFlowLog{
+		NodeID: "node-a",
+		Start:  time.Date(2026, 5, 8, 13, 45, 0, 0, time.UTC),
+		VirtualTraffic: []tailscale.TrafficStats{
+			{Proto: 6, Src: "100.64.0.1:1234", Dst: "100.64.0.2:443", TxBytes: ^uint64(0), TxPkts: 1},
+			{Proto: 6, Src: "100.64.0.1:1234", Dst: "100.64.0.2:443", TxBytes: 10, TxPkts: 1},
+		},
+	})
+	if len(flows) != 1 || flows[0].TxBytes != 10 {
+		t.Fatalf("converted flows = %+v, want only the in-range counter", flows)
+	}
+}
+
+func TestConvertMapLogSkipsFractionalAndOutOfRangeCounters(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	flows := poller.convertMapLog(map[string]any{
+		"nodeId": "node-a",
+		"start":  "2026-05-08T13:45:00Z",
+		"virtualTraffic": []any{
+			map[string]any{"proto": float64(6), "src": "100.64.0.1:1234", "dst": "100.64.0.2:443", "txBytes": float64(1 << 63), "txPkts": float64(1)},
+			map[string]any{"proto": float64(6), "src": "100.64.0.1:1234", "dst": "100.64.0.2:443", "txBytes": float64(10), "txPkts": float64(1.5)},
+			map[string]any{"proto": float64(6), "src": "100.64.0.1:1234", "dst": "100.64.0.2:443", "txBytes": float64(10), "txPkts": float64(1)},
+		},
+	})
+	if len(flows) != 1 || flows[0].TxBytes != 10 || flows[0].TxPkts != 1 {
+		t.Fatalf("converted flows = %+v, want only the valid row", flows)
+	}
+}
+
+func TestConvertMapLogRejectsNegativeCounters(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	flows := poller.convertMapLog(map[string]any{
+		"nodeId": "node-a",
+		"start":  "2026-05-08T13:45:00Z",
+		"virtualTraffic": []any{
+			map[string]any{
+				"proto": 6, "src": "100.64.0.1:1234", "dst": "100.64.0.2:443",
+				"txBytes": -1, "txPkts": 1,
+			},
+		},
+	})
+	if len(flows) != 0 {
+		t.Fatalf("converted flows = %+v, want negative counter row rejected", flows)
+	}
+}

--- a/backend/internal/services/log_converter_test.go
+++ b/backend/internal/services/log_converter_test.go
@@ -1,0 +1,52 @@
+package services
+
+import "testing"
+
+func TestExtractEndpointHandlesIPv4AndIPv6(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		ip   string
+		port int
+	}{
+		{name: "ipv4 with port", addr: "192.0.2.10:443", ip: "192.0.2.10", port: 443},
+		{name: "bracketed ipv6 with port", addr: "[2001:db8::10]:8443", ip: "2001:db8::10", port: 8443},
+		{name: "bare ipv6", addr: "fd7a:115c:a1e0::1", ip: "fd7a:115c:a1e0::1", port: 0},
+		{name: "opaque node id", addr: "n5ZfK4a5pz11CNTRL", ip: "n5ZfK4a5pz11CNTRL", port: 0},
+		{name: "hostname with port", addr: "host.example:443", ip: "host.example", port: 443},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractIP(tt.addr); got != tt.ip {
+				t.Fatalf("extractIP(%q) = %q, want %q", tt.addr, got, tt.ip)
+			}
+			if got := extractPort(tt.addr); got != tt.port {
+				t.Fatalf("extractPort(%q) = %d, want %d", tt.addr, got, tt.port)
+			}
+		})
+	}
+}
+
+func TestExtractEndpointRejectsMalformedPortsWithoutTruncatingHosts(t *testing.T) {
+	tests := []struct {
+		addr string
+		ip   string
+	}{
+		{addr: "192.0.2.10:not-a-port", ip: "192.0.2.10"},
+		{addr: "192.0.2.10:65536", ip: "192.0.2.10"},
+		{addr: "[2001:db8::10]:70000", ip: "2001:db8::10"},
+		{addr: "[2001:db8::10]bad", ip: "[2001:db8::10]bad"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			if got := extractIP(tt.addr); got != tt.ip {
+				t.Fatalf("extractIP(%q) = %q, want %q", tt.addr, got, tt.ip)
+			}
+			if got := extractPort(tt.addr); got != 0 {
+				t.Fatalf("extractPort(%q) = %d, want 0", tt.addr, got)
+			}
+		})
+	}
+}

--- a/backend/internal/services/object_store_source.go
+++ b/backend/internal/services/object_store_source.go
@@ -262,7 +262,7 @@ func (s *ObjectStoreSource) listObjects(ctx context.Context, start, end time.Tim
 			for _, item := range page.Contents {
 				key := aws.ToString(item.Key)
 				logTime, ok := objectTime(key)
-				if !ok || logTime.Before(start) || logTime.After(end) {
+				if !ok || logTime.Before(start) || !logTime.Before(end) {
 					continue
 				}
 				lastModified := time.Time{}

--- a/backend/internal/services/object_store_source.go
+++ b/backend/internal/services/object_store_source.go
@@ -94,8 +94,7 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 		return 0, 0, end, nil
 	}
 	if len(objects) > s.cfg.MaxObjects {
-		log.Printf("Object-store poll found %d candidate objects; processing newest %d", len(objects), s.cfg.MaxObjects)
-		objects = objects[len(objects)-s.cfg.MaxObjects:]
+		log.Printf("Object-store poll found %d candidate objects; processing up to %d oldest un-ingested objects", len(objects), s.cfg.MaxObjects)
 	}
 
 	processedObjects := 0
@@ -105,6 +104,10 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 	if existingMetadata, err := p.store.GetNodeMetadata(ctx); err == nil && len(existingMetadata) == 0 {
 		shouldBackfillMetadata = true
 	}
+	// Select un-ingested objects after checking the ingestion guard. This keeps
+	// a timestamp-only cursor progressing even when more than MaxObjects share
+	// the same timestamp and the first page has already been seen.
+	selected := make([]flowObject, 0, minInt(len(objects), s.cfg.MaxObjects))
 	for _, obj := range objects {
 		seen, err := p.store.IsObjectIngested(ctx, obj.key)
 		if err != nil {
@@ -127,7 +130,13 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 			}
 			continue
 		}
+		if len(selected) >= s.cfg.MaxObjects {
+			break
+		}
+		selected = append(selected, obj)
+	}
 
+	for _, obj := range selected {
 		flows, nodeMetadata, err := s.readFlowLogs(ctx, p, obj.key)
 		if err != nil {
 			return processedObjects, processedFlows, lastProcessed, fmt.Errorf("failed to read %s: %w", obj.key, err)
@@ -164,6 +173,13 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 	}
 
 	return processedObjects, processedFlows, lastProcessed, nil
+}
+
+func minInt(left, right int) int {
+	if left < right {
+		return left
+	}
+	return right
 }
 
 func (s *ObjectStoreSource) listObjects(ctx context.Context, start, end time.Time) ([]flowObject, error) {

--- a/backend/internal/services/object_store_source.go
+++ b/backend/internal/services/object_store_source.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"path"
 	"sort"
 	"strings"
@@ -49,6 +50,15 @@ func NewObjectStoreSource(ctx context.Context, cfg ObjectStoreConfig) (*ObjectSt
 	if cfg.Bucket == "" {
 		return nil, fmt.Errorf("object-store bucket is required")
 	}
+	if cfg.Endpoint != "" {
+		endpoint, err := url.Parse(cfg.Endpoint)
+		if err != nil || endpoint.Scheme == "" || endpoint.Host == "" {
+			return nil, fmt.Errorf("object-store endpoint must be a valid absolute URL")
+		}
+		if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+			return nil, fmt.Errorf("object-store endpoint must use http or https")
+		}
+	}
 	if cfg.Prefix == "" {
 		cfg.Prefix = "network/"
 	}
@@ -86,6 +96,13 @@ func NewObjectStoreSource(ctx context.Context, cfg ObjectStoreConfig) (*ObjectSt
 }
 
 func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time.Time) (int, int, time.Time, error) {
+	if p == nil || p.store == nil {
+		return 0, 0, start, fmt.Errorf("poller store is required")
+	}
+	if err := s.hydrateMissingMetadata(ctx, p); err != nil {
+		return 0, 0, start, err
+	}
+
 	objects, err := s.listObjects(ctx, start.Add(-s.cfg.Lookback), end)
 	if err != nil {
 		return 0, 0, time.Time{}, err
@@ -100,10 +117,6 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 	processedObjects := 0
 	processedFlows := 0
 	lastProcessed := start
-	shouldBackfillMetadata := false
-	if existingMetadata, err := p.store.GetNodeMetadata(ctx); err == nil && len(existingMetadata) == 0 {
-		shouldBackfillMetadata = true
-	}
 	// Select un-ingested objects after checking the ingestion guard. This keeps
 	// a timestamp-only cursor progressing even when more than MaxObjects share
 	// the same timestamp and the first page has already been seen.
@@ -114,17 +127,6 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 			return processedObjects, processedFlows, lastProcessed, err
 		}
 		if seen {
-			if shouldBackfillMetadata {
-				_, nodeMetadata, err := s.readFlowLogs(ctx, p, obj.key)
-				if err != nil {
-					log.Printf("Warning: failed to backfill node metadata from %s: %v", obj.key, err)
-				} else if len(nodeMetadata) > 0 {
-					p.deviceCache.UpsertNodeMetadata(nodeMetadata)
-					if err := p.store.UpsertNodeMetadata(ctx, nodeMetadata); err != nil {
-						log.Printf("Warning: failed to persist node metadata from %s: %v", obj.key, err)
-					}
-				}
-			}
 			if obj.logTime.After(lastProcessed) {
 				lastProcessed = obj.logTime
 			}
@@ -173,6 +175,42 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 	}
 
 	return processedObjects, processedFlows, lastProcessed, nil
+}
+
+// hydrateMissingMetadata repairs historical node identities independently of
+// the flow cursor and S3 lookback. This matters after a partial metadata-table
+// loss or when a database created before metadata hydration is upgraded.
+func (s *ObjectStoreSource) hydrateMissingMetadata(ctx context.Context, p *Poller) error {
+	keys, err := p.store.GetObjectsNeedingMetadata(ctx, s.cfg.MaxObjects)
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		_, nodeMetadata, err := s.readFlowLogs(ctx, p, key)
+		if err != nil {
+			return fmt.Errorf("failed to hydrate metadata from %s: %w", key, err)
+		}
+		if len(nodeMetadata) > 0 {
+			p.deviceCache.UpsertNodeMetadata(nodeMetadata)
+			if err := p.store.UpsertNodeMetadata(ctx, nodeMetadata); err != nil {
+				return fmt.Errorf("failed to persist metadata from %s: %w", key, err)
+			}
+		}
+		if err := p.store.MarkObjectMetadataHydrated(ctx, key, objectMetadataIDs(nodeMetadata)); err != nil {
+			return fmt.Errorf("failed to mark metadata hydrated for %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func objectMetadataIDs(nodes []database.NodeMetadata) []string {
+	ids := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if node.NodeID != "" {
+			ids = append(ids, node.NodeID)
+		}
+	}
+	return ids
 }
 
 func minInt(left, right int) int {

--- a/backend/internal/services/object_store_source.go
+++ b/backend/internal/services/object_store_source.go
@@ -99,8 +99,11 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 	if p == nil || p.store == nil {
 		return 0, 0, start, fmt.Errorf("poller store is required")
 	}
+	// Metadata hydration repairs an auxiliary index for already-ingested
+	// objects. A stale or unreadable historical object must not prevent newer
+	// objects from being listed and ingested, so retain the error and continue.
 	if err := s.hydrateMissingMetadata(ctx, p); err != nil {
-		return 0, 0, start, err
+		log.Printf("Warning: historical metadata hydration incomplete: %v", err)
 	}
 
 	objects, err := s.listObjects(ctx, start.Add(-s.cfg.Lookback), end)
@@ -117,6 +120,8 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 	processedObjects := 0
 	processedFlows := 0
 	lastProcessed := start
+	var firstReadErr error
+	var blockedAt time.Time
 	// Select un-ingested objects after checking the ingestion guard. This keeps
 	// a timestamp-only cursor progressing even when more than MaxObjects share
 	// the same timestamp and the first page has already been seen.
@@ -141,7 +146,14 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 	for _, obj := range selected {
 		flows, nodeMetadata, err := s.readFlowLogs(ctx, p, obj.key)
 		if err != nil {
-			return processedObjects, processedFlows, lastProcessed, fmt.Errorf("failed to read %s: %w", obj.key, err)
+			if firstReadErr == nil {
+				firstReadErr = fmt.Errorf("failed to read %s: %w", obj.key, err)
+			}
+			if blockedAt.IsZero() || obj.logTime.Before(blockedAt) {
+				blockedAt = obj.logTime
+			}
+			log.Printf("Warning: skipping unreadable object %s; later objects will still be attempted: %v", obj.key, err)
+			continue
 		}
 		if len(nodeMetadata) > 0 {
 			p.deviceCache.UpsertNodeMetadata(nodeMetadata)
@@ -161,7 +173,6 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 			Bandwidth:     totalBandwidth,
 			NodeBandwidth: nodeBandwidth,
 			TrafficStats:  trafficStats,
-			PollEnd:       pollEnd,
 		}); err != nil {
 			return processedObjects, processedFlows, lastProcessed, err
 		}
@@ -173,8 +184,14 @@ func (s *ObjectStoreSource) Poll(ctx context.Context, p *Poller, start, end time
 			lastProcessed = pollEnd
 		}
 	}
+	// Keep the cursor at the earliest unreadable object so a transient or
+	// repaired source object is retried on the next poll. Objects after it may
+	// still be ingested, but a failure must not silently advance past the gap.
+	if !blockedAt.IsZero() && blockedAt.Before(lastProcessed) {
+		lastProcessed = blockedAt
+	}
 
-	return processedObjects, processedFlows, lastProcessed, nil
+	return processedObjects, processedFlows, lastProcessed, firstReadErr
 }
 
 // hydrateMissingMetadata repairs historical node identities independently of
@@ -185,22 +202,31 @@ func (s *ObjectStoreSource) hydrateMissingMetadata(ctx context.Context, p *Polle
 	if err != nil {
 		return err
 	}
+	var firstErr error
 	for _, key := range keys {
 		_, nodeMetadata, err := s.readFlowLogs(ctx, p, key)
 		if err != nil {
-			return fmt.Errorf("failed to hydrate metadata from %s: %w", key, err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("failed to hydrate metadata from %s: %w", key, err)
+			}
+			continue
 		}
 		if len(nodeMetadata) > 0 {
 			p.deviceCache.UpsertNodeMetadata(nodeMetadata)
 			if err := p.store.UpsertNodeMetadata(ctx, nodeMetadata); err != nil {
-				return fmt.Errorf("failed to persist metadata from %s: %w", key, err)
+				if firstErr == nil {
+					firstErr = fmt.Errorf("failed to persist metadata from %s: %w", key, err)
+				}
+				continue
 			}
 		}
 		if err := p.store.MarkObjectMetadataHydrated(ctx, key, objectMetadataIDs(nodeMetadata)); err != nil {
-			return fmt.Errorf("failed to mark metadata hydrated for %s: %w", key, err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("failed to mark metadata hydrated for %s: %w", key, err)
+			}
 		}
 	}
-	return nil
+	return firstErr
 }
 
 func objectMetadataIDs(nodes []database.NodeMetadata) []string {

--- a/backend/internal/services/object_store_source_test.go
+++ b/backend/internal/services/object_store_source_test.go
@@ -397,6 +397,100 @@ func TestObjectStoreRepairsPartiallyMissingMetadataOutsideLookback(t *testing.T)
 	}
 }
 
+func TestObjectStoreContinuesWhenHistoricalMetadataObjectIsMalformed(t *testing.T) {
+	oldKey := "network/2026/05/08/a/2026-05-08-13-30-00.ndjson"
+	newKey := "network/2026/05/08/b/2026-05-08-13-45-00.ndjson"
+	objects := []testObject{
+		{key: oldKey, body: []byte("{malformed\n")},
+		testFlowObject(t, newKey, "node-b", 20, false),
+	}
+	source, server := newTestObjectStore(t, objects, 10)
+	defer server.Close()
+	poller, db := newObjectStoreTestPoller(t, source, 10)
+	ctx := context.Background()
+	base := time.Date(2026, 5, 8, 13, 0, 0, 0, time.UTC)
+
+	// Seed the malformed object as an already-ingested row needing metadata
+	// repair. It must not block ingestion of the newer valid object.
+	if err := db.store.CommitObjectIngest(ctx, database.ObjectIngestResult{
+		Key:          oldKey,
+		LastModified: base,
+		PollEnd:      base.Add(30 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	metadataDB, err := sql.Open("sqlite", db.dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := metadataDB.ExecContext(ctx,
+		"UPDATE ingested_objects SET metadata_hydrated = 0 WHERE object_key = ?", oldKey,
+	); err != nil {
+		_ = metadataDB.Close()
+		t.Fatal(err)
+	}
+	if err := metadataDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := poller.pollObjectStore(ctx, base, base.Add(time.Hour)); err != nil {
+		t.Fatalf("metadata repair should not block newer ingestion: %v", err)
+	}
+	seen, err := db.store.IsObjectIngested(ctx, newKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !seen {
+		t.Fatalf("expected valid object %s to be ingested", newKey)
+	}
+	pairs, err := db.store.GetNodePairAggregates(ctx, base, base.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pairs) != 1 || pairs[0].TxBytes != 20 {
+		t.Fatalf("pairs = %+v, want valid object traffic despite malformed metadata object", pairs)
+	}
+}
+
+func TestObjectStoreProcessesLaterObjectsWhenEarlierCandidateIsMalformed(t *testing.T) {
+	oldKey := "network/2026/05/08/a/2026-05-08-13-30-00.ndjson"
+	newKey := "network/2026/05/08/b/2026-05-08-13-45-00.ndjson"
+	source, server := newTestObjectStore(t, []testObject{
+		{key: oldKey, body: []byte("{malformed\n")},
+		testFlowObject(t, newKey, "node-b", 20, false),
+	}, 10)
+	defer server.Close()
+	poller, db := newObjectStoreTestPoller(t, source, 10)
+	ctx := context.Background()
+	base := time.Date(2026, 5, 8, 13, 0, 0, 0, time.UTC)
+
+	err := poller.pollObjectStore(ctx, base, base.Add(time.Hour))
+	if err == nil || !strings.Contains(err.Error(), oldKey) {
+		t.Fatalf("malformed candidate error = %v, want error naming %s", err, oldKey)
+	}
+	seen, err := db.store.IsObjectIngested(ctx, newKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !seen {
+		t.Fatalf("expected later valid object %s to be ingested", newKey)
+	}
+	state, err := db.store.GetPollState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.LastPollEnd.Equal(base.Add(30 * time.Minute)) {
+		t.Fatalf("poll cursor = %v, want earliest unreadable object at %v", state.LastPollEnd, base.Add(30*time.Minute))
+	}
+	pairs, err := db.store.GetNodePairAggregates(ctx, base, base.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pairs) != 1 || pairs[0].TxBytes != 20 {
+		t.Fatalf("pairs = %+v, want later valid object traffic", pairs)
+	}
+}
+
 func TestObjectStorePollPropagatesCancellation(t *testing.T) {
 	source, server := newTestObjectStore(t, nil, 10)
 	defer server.Close()

--- a/backend/internal/services/object_store_source_test.go
+++ b/backend/internal/services/object_store_source_test.go
@@ -1,8 +1,25 @@
 package services
 
 import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"html"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/rajsinghtech/tsflow/backend/internal/database"
+	_ "modernc.org/sqlite"
 )
 
 func TestObjectTimeSupportedCompressionSuffixes(t *testing.T) {
@@ -31,5 +48,312 @@ func TestObjectTimeSupportedCompressionSuffixes(t *testing.T) {
 func TestObjectTimeRejectsUnknownSuffix(t *testing.T) {
 	if got, ok := objectTime("network/2026/05/08/2026-05-08-13-45-00.json.br"); ok {
 		t.Fatalf("expected unsupported suffix to be rejected, got %s", got)
+	}
+}
+
+type testObject struct {
+	key  string
+	body []byte
+}
+
+type objectStoreTestDB struct {
+	store   *database.SQLiteStore
+	dbPath  string
+	cleanup func()
+}
+
+func newTestObjectStore(t *testing.T, objects []testObject, maxObjects int) (*ObjectStoreSource, *httptest.Server) {
+	t.Helper()
+	byKey := make(map[string][]byte, len(objects))
+	for _, object := range objects {
+		byKey[object.key] = object.body
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("list-type") == "2" {
+			keys := make([]string, 0, len(byKey))
+			for key := range byKey {
+				keys = append(keys, key)
+			}
+			sort.Sort(sort.StringSlice(keys))
+
+			var response bytes.Buffer
+			response.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+			response.WriteString(`<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`)
+			response.WriteString(`<Name>bucket</Name><KeyCount>`)
+			response.WriteString(strconv.Itoa(len(keys)))
+			response.WriteString(`</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated>`)
+			for _, key := range keys {
+				response.WriteString(`<Contents><Key>`)
+				response.WriteString(html.EscapeString(key))
+				response.WriteString(`</Key><LastModified>2026-05-08T13:45:00Z</LastModified><ETag>"test"</ETag><Size>`)
+				response.WriteString(strconv.Itoa(len(byKey[key])))
+				response.WriteString(`</Size><StorageClass>STANDARD</StorageClass></Contents>`)
+			}
+			response.WriteString(`</ListBucketResult>`)
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write(response.Bytes())
+			return
+		}
+
+		key := strings.TrimPrefix(path.Clean(r.URL.Path), "/bucket/")
+		body, ok := byKey[key]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+
+	awsConfig := aws.Config{
+		Region:      "test",
+		Credentials: credentials.NewStaticCredentialsProvider("access", "secret", ""),
+		HTTPClient:  server.Client(),
+	}
+	client := s3.NewFromConfig(awsConfig, func(options *s3.Options) {
+		options.BaseEndpoint = aws.String(server.URL)
+		options.UsePathStyle = true
+	})
+	source := &ObjectStoreSource{
+		cfg: ObjectStoreConfig{
+			Bucket:     "bucket",
+			Prefix:     "network",
+			Lookback:   time.Hour,
+			MaxObjects: maxObjects,
+		},
+		client: client,
+	}
+	return source, server
+}
+
+func testFlowObject(t *testing.T, key, nodeID string, bytes int64, withMetadata bool) testObject {
+	t.Helper()
+	logMap := map[string]any{
+		"nodeId": nodeID,
+		"start":  "2026-05-08T13:45:00Z",
+		"virtualTraffic": []any{map[string]any{
+			"proto":   6,
+			"src":     "100.64.0.1:1234",
+			"dst":     "100.64.0.2:443",
+			"txBytes": bytes,
+			"txPkts":  1,
+		}},
+	}
+	if withMetadata {
+		logMap["srcNode"] = map[string]any{
+			"nodeId":    "node-a",
+			"name":      "alpha.example.ts.net",
+			"addresses": []string{"100.64.0.1"},
+			"user":      "alice@example.com",
+			"tags":      []string{"tag:prod"},
+		}
+		logMap["dstNodes"] = []any{map[string]any{
+			"nodeId":    "node-b",
+			"name":      "beta.example.ts.net",
+			"addresses": []string{"100.64.0.2"},
+		}}
+	}
+	body, err := json.Marshal(logMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return testObject{key: key, body: append(body, '\n')}
+}
+
+func newObjectStoreTestPoller(t *testing.T, source *ObjectStoreSource, maxObjects int) (*Poller, *objectStoreTestDB) {
+	t.Helper()
+	dbPath := t.TempDir() + "/test.db"
+	store, err := database.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Init(context.Background()); err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	db := &objectStoreTestDB{store: store, dbPath: dbPath}
+	db.cleanup = func() {
+		if db.store != nil {
+			_ = db.store.Close()
+		}
+	}
+	t.Cleanup(func() { db.cleanup() })
+	poller := NewPoller(nil, store, PollerConfig{
+		PollInterval:       time.Hour,
+		InitialBackfill:    time.Hour,
+		Retention:          24 * time.Hour,
+		CleanupInterval:    time.Hour,
+		DeviceCacheRefresh: time.Hour,
+		FlowBackend:        "s3",
+		ObjectStore:        source.cfg,
+	})
+	poller.ConfigureObjectStore(source)
+	if poller.config.ObjectStore.MaxObjects != maxObjects {
+		t.Fatalf("test poller max objects = %d, want %d", poller.config.ObjectStore.MaxObjects, maxObjects)
+	}
+	return poller, db
+}
+
+func TestObjectStorePollCapsObjectsAndUsesDeterministicEqualTimestampOrder(t *testing.T) {
+	objects := []testObject{
+		testFlowObject(t, "network/2026/05/08/c/2026-05-08-13-45-00.ndjson", "node-c", 30, false),
+		testFlowObject(t, "network/2026/05/08/a/2026-05-08-13-45-00.ndjson", "node-a", 10, false),
+		testFlowObject(t, "network/2026/05/08/b/2026-05-08-13-45-00.ndjson", "node-b", 20, false),
+	}
+	source, server := newTestObjectStore(t, objects, 2)
+	defer server.Close()
+	poller, db := newObjectStoreTestPoller(t, source, 2)
+	store := db.store
+	ctx := context.Background()
+	start := time.Date(2026, 5, 8, 13, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 8, 14, 0, 0, 0, time.UTC)
+
+	if err := poller.pollObjectStore(ctx, start, end); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{objects[1].key, objects[2].key} {
+		seen, err := store.IsObjectIngested(ctx, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !seen {
+			t.Fatalf("expected %s to be ingested", key)
+		}
+	}
+	seen, err := store.IsObjectIngested(ctx, objects[0].key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen {
+		t.Fatalf("expected cap to defer %s", objects[0].key)
+	}
+
+	pairs, err := store.GetNodePairAggregates(ctx, start, end, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pairs) != 1 || pairs[0].TxBytes != 30 || pairs[0].FlowCount != 2 {
+		t.Fatalf("first capped poll pairs = %+v, want 30 bytes and two flows", pairs)
+	}
+	state, err := store.GetPollState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	objectTime, _ := objectTime(objects[0].key)
+	if !state.LastPollEnd.Equal(objectTime) {
+		t.Fatalf("poll cursor = %v, want %v", state.LastPollEnd, objectTime)
+	}
+
+	if err := poller.pollObjectStore(ctx, state.LastPollEnd, end); err != nil {
+		t.Fatal(err)
+	}
+	seen, err = store.IsObjectIngested(ctx, objects[0].key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !seen {
+		t.Fatalf("expected deferred object %s to be ingested on repoll", objects[0].key)
+	}
+	pairs, err = store.GetNodePairAggregates(ctx, start, end, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pairs) != 1 || pairs[0].TxBytes != 60 || pairs[0].FlowCount != 3 {
+		t.Fatalf("after repoll pairs = %+v, want 60 bytes and three flows", pairs)
+	}
+}
+
+func TestObjectStoreRepollAndRestartAreIdempotentAndBackfillMetadata(t *testing.T) {
+	key := "network/2026/05/08/2026-05-08-13-45-00.ndjson"
+	source, server := newTestObjectStore(t, []testObject{
+		testFlowObject(t, key, "node-a", 25, true),
+	}, 10)
+	defer server.Close()
+	poller, db := newObjectStoreTestPoller(t, source, 10)
+	store := db.store
+	ctx := context.Background()
+	start := time.Date(2026, 5, 8, 13, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 8, 14, 0, 0, 0, time.UTC)
+
+	if err := poller.pollObjectStore(ctx, start, end); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db.store = nil
+	metadataDB, err := sql.Open("sqlite", db.dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := metadataDB.ExecContext(ctx, "DELETE FROM node_metadata"); err != nil {
+		_ = metadataDB.Close()
+		t.Fatal(err)
+	}
+	if err := metadataDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err = database.NewSQLiteStore(db.dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Init(ctx); err != nil {
+		_ = store.Close()
+		t.Fatal(err)
+	}
+	db.store = store
+
+	// A fresh poller simulates a process restart while retaining the database
+	// ingestion guard and cursor.
+	restarted := NewPoller(nil, store, poller.config)
+	restarted.ConfigureObjectStore(source)
+	if err := restarted.pollObjectStore(ctx, time.Date(2026, 5, 8, 13, 45, 0, 0, time.UTC), end); err != nil {
+		t.Fatal(err)
+	}
+
+	pairs, err := store.GetNodePairAggregates(ctx, start, end, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pairs) != 1 || pairs[0].TxBytes != 25 || pairs[0].FlowCount != 1 {
+		t.Fatalf("repoll double-counted object: %+v", pairs)
+	}
+	metadata, err := store.GetNodeMetadata(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metadata) != 2 {
+		t.Fatalf("metadata rows = %+v, want source and destination metadata", metadata)
+	}
+	state, err := store.GetPollState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.LastPollEnd.Equal(end) {
+		t.Fatalf("restart cursor = %v, want %v after an all-seen poll", state.LastPollEnd, end)
+	}
+
+	if err := restarted.pollObjectStore(ctx, state.LastPollEnd, end); err != nil {
+		t.Fatal(err)
+	}
+	pairs, err = store.GetNodePairAggregates(ctx, start, end, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pairs) != 1 || pairs[0].TxBytes != 25 || pairs[0].FlowCount != 1 {
+		t.Fatalf("second repoll double-counted object: %+v", pairs)
+	}
+}
+
+func TestObjectStorePollPropagatesCancellation(t *testing.T) {
+	source, server := newTestObjectStore(t, nil, 10)
+	defer server.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	poller, _ := newObjectStoreTestPoller(t, source, 10)
+	start := time.Date(2026, 5, 8, 13, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 8, 14, 0, 0, 0, time.UTC)
+	if err := poller.pollObjectStore(ctx, start, end); err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("poll cancellation error = %v", err)
 	}
 }

--- a/backend/internal/services/object_store_source_test.go
+++ b/backend/internal/services/object_store_source_test.go
@@ -51,6 +51,17 @@ func TestObjectTimeRejectsUnknownSuffix(t *testing.T) {
 	}
 }
 
+func TestNewObjectStoreSourceRejectsInvalidEndpoint(t *testing.T) {
+	for _, endpoint := range []string{"object-store.test", "ftp://object-store.test"} {
+		if _, err := NewObjectStoreSource(context.Background(), ObjectStoreConfig{
+			Bucket:   "bucket",
+			Endpoint: endpoint,
+		}); err == nil {
+			t.Fatalf("endpoint %q was accepted", endpoint)
+		}
+	}
+}
+
 type testObject struct {
 	key  string
 	body []byte
@@ -228,7 +239,7 @@ func TestObjectStorePollCapsObjectsAndUsesDeterministicEqualTimestampOrder(t *te
 		t.Fatalf("expected cap to defer %s", objects[0].key)
 	}
 
-	pairs, err := store.GetNodePairAggregates(ctx, start, end, 60)
+	pairs, err := store.GetNodePairAggregates(ctx, start, end)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +265,7 @@ func TestObjectStorePollCapsObjectsAndUsesDeterministicEqualTimestampOrder(t *te
 	if !seen {
 		t.Fatalf("expected deferred object %s to be ingested on repoll", objects[0].key)
 	}
-	pairs, err = store.GetNodePairAggregates(ctx, start, end, 60)
+	pairs, err = store.GetNodePairAggregates(ctx, start, end)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +322,7 @@ func TestObjectStoreRepollAndRestartAreIdempotentAndBackfillMetadata(t *testing.
 		t.Fatal(err)
 	}
 
-	pairs, err := store.GetNodePairAggregates(ctx, start, end, 60)
+	pairs, err := store.GetNodePairAggregates(ctx, start, end)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,12 +347,53 @@ func TestObjectStoreRepollAndRestartAreIdempotentAndBackfillMetadata(t *testing.
 	if err := restarted.pollObjectStore(ctx, state.LastPollEnd, end); err != nil {
 		t.Fatal(err)
 	}
-	pairs, err = store.GetNodePairAggregates(ctx, start, end, 60)
+	pairs, err = store.GetNodePairAggregates(ctx, start, end)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(pairs) != 1 || pairs[0].TxBytes != 25 || pairs[0].FlowCount != 1 {
 		t.Fatalf("second repoll double-counted object: %+v", pairs)
+	}
+}
+
+func TestObjectStoreRepairsPartiallyMissingMetadataOutsideLookback(t *testing.T) {
+	key := "network/2026/05/08/2026-05-08-13-45-00.ndjson"
+	source, server := newTestObjectStore(t, []testObject{
+		testFlowObject(t, key, "node-a", 25, true),
+	}, 10)
+	defer server.Close()
+	poller, db := newObjectStoreTestPoller(t, source, 10)
+	store := db.store
+	ctx := context.Background()
+	start := time.Date(2026, 5, 8, 13, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 8, 14, 0, 0, 0, time.UTC)
+
+	if err := poller.pollObjectStore(ctx, start, end); err != nil {
+		t.Fatal(err)
+	}
+	metadataDB, err := sql.Open("sqlite", db.dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer metadataDB.Close()
+	if _, err := metadataDB.ExecContext(ctx, "DELETE FROM node_metadata WHERE node_id = ?", "node-b"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := metadataDB.ExecContext(ctx, "UPDATE ingested_objects SET metadata_hydrated = 1 WHERE object_key = ?", key); err != nil {
+		t.Fatal(err)
+	}
+
+	// The object is outside the requested range and the source lookback. The
+	// metadata index must still identify it for repair before listing objects.
+	if err := poller.pollObjectStore(ctx, end, end.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := store.GetNodeMetadata(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metadata) != 2 {
+		t.Fatalf("metadata rows = %+v, want both nodes after repair", metadata)
 	}
 }
 

--- a/backend/internal/services/object_store_source_test.go
+++ b/backend/internal/services/object_store_source_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -18,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/klauspost/compress/zstd"
 	"github.com/rajsinghtech/tsflow/backend/internal/database"
 	_ "modernc.org/sqlite"
 )
@@ -74,6 +76,10 @@ type objectStoreTestDB struct {
 }
 
 func newTestObjectStore(t *testing.T, objects []testObject, maxObjects int) (*ObjectStoreSource, *httptest.Server) {
+	return newTestObjectStoreWithPageSize(t, objects, maxObjects, 0)
+}
+
+func newTestObjectStoreWithPageSize(t *testing.T, objects []testObject, maxObjects, pageSize int) (*ObjectStoreSource, *httptest.Server) {
 	t.Helper()
 	byKey := make(map[string][]byte, len(objects))
 	for _, object := range objects {
@@ -88,13 +94,40 @@ func newTestObjectStore(t *testing.T, objects []testObject, maxObjects int) (*Ob
 			}
 			sort.Sort(sort.StringSlice(keys))
 
+			pageStart := 0
+			if token := r.URL.Query().Get("continuation-token"); token != "" {
+				const tokenPrefix = "page-"
+				if !strings.HasPrefix(token, tokenPrefix) {
+					http.Error(w, "invalid continuation token", http.StatusBadRequest)
+					return
+				}
+				var err error
+				pageStart, err = strconv.Atoi(strings.TrimPrefix(token, tokenPrefix))
+				if err != nil || pageStart < 0 || pageStart > len(keys) {
+					http.Error(w, "invalid continuation token", http.StatusBadRequest)
+					return
+				}
+			}
+			pageEnd := len(keys)
+			if pageSize > 0 && pageStart+pageSize < pageEnd {
+				pageEnd = pageStart + pageSize
+			}
+			pageKeys := keys[pageStart:pageEnd]
+
 			var response bytes.Buffer
 			response.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
 			response.WriteString(`<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`)
 			response.WriteString(`<Name>bucket</Name><KeyCount>`)
-			response.WriteString(strconv.Itoa(len(keys)))
-			response.WriteString(`</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated>`)
-			for _, key := range keys {
+			response.WriteString(strconv.Itoa(len(pageKeys)))
+			response.WriteString(`</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>`)
+			response.WriteString(strconv.FormatBool(pageEnd < len(keys)))
+			response.WriteString(`</IsTruncated>`)
+			if pageEnd < len(keys) {
+				response.WriteString(`<NextContinuationToken>page-`)
+				response.WriteString(strconv.Itoa(pageEnd))
+				response.WriteString(`</NextContinuationToken>`)
+			}
+			for _, key := range pageKeys {
 				response.WriteString(`<Contents><Key>`)
 				response.WriteString(html.EscapeString(key))
 				response.WriteString(`</Key><LastModified>2026-05-08T13:45:00Z</LastModified><ETag>"test"</ETag><Size>`)
@@ -138,15 +171,19 @@ func newTestObjectStore(t *testing.T, objects []testObject, maxObjects int) (*Ob
 }
 
 func testFlowObject(t *testing.T, key, nodeID string, bytes int64, withMetadata bool) testObject {
+	return testFlowObjectAt(t, key, nodeID, time.Date(2026, 5, 8, 13, 45, 0, 0, time.UTC), bytes, withMetadata)
+}
+
+func testFlowObjectAt(t *testing.T, key, nodeID string, loggedAt time.Time, byteCount int64, withMetadata bool) testObject {
 	t.Helper()
 	logMap := map[string]any{
 		"nodeId": nodeID,
-		"start":  "2026-05-08T13:45:00Z",
+		"start":  loggedAt.UTC().Format(time.RFC3339),
 		"virtualTraffic": []any{map[string]any{
 			"proto":   6,
 			"src":     "100.64.0.1:1234",
 			"dst":     "100.64.0.2:443",
-			"txBytes": bytes,
+			"txBytes": byteCount,
 			"txPkts":  1,
 		}},
 	}
@@ -171,7 +208,42 @@ func testFlowObject(t *testing.T, key, nodeID string, bytes int64, withMetadata 
 	return testObject{key: key, body: append(body, '\n')}
 }
 
-func newObjectStoreTestPoller(t *testing.T, source *ObjectStoreSource, maxObjects int) (*Poller, *objectStoreTestDB) {
+func compressedTestFlowObject(t *testing.T, key, nodeID string, loggedAt time.Time, byteCount int64, suffix string) testObject {
+	t.Helper()
+	object := testFlowObjectAt(t, key, nodeID, loggedAt, byteCount, false)
+	if suffix == "" {
+		return object
+	}
+
+	var compressed bytes.Buffer
+	switch suffix {
+	case ".gz", ".gzip":
+		writer := gzip.NewWriter(&compressed)
+		if _, err := writer.Write(object.body); err != nil {
+			t.Fatalf("compress gzip object: %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close gzip object: %v", err)
+		}
+	case ".zst", ".zstd":
+		writer, err := zstd.NewWriter(&compressed)
+		if err != nil {
+			t.Fatalf("create zstd writer: %v", err)
+		}
+		if _, err := writer.Write(object.body); err != nil {
+			t.Fatalf("compress zstd object: %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close zstd object: %v", err)
+		}
+	default:
+		t.Fatalf("unsupported test compression suffix %q", suffix)
+	}
+	object.body = compressed.Bytes()
+	return object
+}
+
+func newObjectStoreTestPollerWithService(t *testing.T, source *ObjectStoreSource, maxObjects int, tsService *TailscaleService) (*Poller, *objectStoreTestDB) {
 	t.Helper()
 	dbPath := t.TempDir() + "/test.db"
 	store, err := database.NewSQLiteStore(dbPath)
@@ -189,7 +261,7 @@ func newObjectStoreTestPoller(t *testing.T, source *ObjectStoreSource, maxObject
 		}
 	}
 	t.Cleanup(func() { db.cleanup() })
-	poller := NewPoller(nil, store, PollerConfig{
+	poller := NewPoller(tsService, store, PollerConfig{
 		PollInterval:       time.Hour,
 		InitialBackfill:    time.Hour,
 		Retention:          24 * time.Hour,
@@ -203,6 +275,116 @@ func newObjectStoreTestPoller(t *testing.T, source *ObjectStoreSource, maxObject
 		t.Fatalf("test poller max objects = %d, want %d", poller.config.ObjectStore.MaxObjects, maxObjects)
 	}
 	return poller, db
+}
+
+func newObjectStoreTestPoller(t *testing.T, source *ObjectStoreSource, maxObjects int) (*Poller, *objectStoreTestDB) {
+	return newObjectStoreTestPollerWithService(t, source, maxObjects, nil)
+}
+
+func TestObjectStorePollsRealGzipAndZstdBodies(t *testing.T) {
+	base := time.Date(2026, 5, 8, 13, 45, 0, 0, time.UTC)
+	suffixes := []string{".gz", ".gzip", ".zst", ".zstd"}
+	objects := make([]testObject, 0, len(suffixes))
+	for index, suffix := range suffixes {
+		key := "network/2026/05/08/2026-05-08-13-45-0" + strconv.Itoa(index) + ".ndjson" + suffix
+		objects = append(objects, compressedTestFlowObject(t, key, "node-compressed", base, int64(index+1), suffix))
+	}
+	source, server := newTestObjectStore(t, objects, len(objects))
+	defer server.Close()
+	poller, db := newObjectStoreTestPoller(t, source, len(objects))
+	ctx := context.Background()
+	if err := poller.pollObjectStore(ctx, base.Add(-time.Minute), base.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, object := range objects {
+		seen, err := db.store.IsObjectIngested(ctx, object.key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !seen {
+			t.Fatalf("expected compressed object %s to be ingested", object.key)
+		}
+	}
+	pairs, err := db.store.GetNodePairAggregates(ctx, base.Add(-time.Minute), base.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pairs) != 1 || pairs[0].TxBytes != 10 || pairs[0].FlowCount != int64(len(objects)) {
+		t.Fatalf("compressed aggregate = %+v, want 10 bytes and %d flows", pairs, len(objects))
+	}
+}
+
+func TestObjectStorePollPaginatesAndUsesHalfOpenEnd(t *testing.T) {
+	base := time.Date(2026, 5, 8, 13, 0, 0, 0, time.UTC)
+	objects := []testObject{
+		testFlowObjectAt(t, "network/2026/05/08/a/2026-05-08-13-00-00.ndjson", "node-a", base, 10, false),
+		testFlowObjectAt(t, "network/2026/05/08/b/2026-05-08-13-30-00.ndjson", "node-b", base.Add(30*time.Minute), 20, false),
+		testFlowObjectAt(t, "network/2026/05/08/c/2026-05-08-14-00-00.ndjson", "node-c", base.Add(time.Hour), 40, false),
+	}
+	source, server := newTestObjectStoreWithPageSize(t, objects, 10, 1)
+	defer server.Close()
+	poller, db := newObjectStoreTestPoller(t, source, 10)
+	ctx := context.Background()
+	end := base.Add(time.Hour)
+	if err := poller.pollObjectStore(ctx, base, end); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, object := range objects[:2] {
+		seen, err := db.store.IsObjectIngested(ctx, object.key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !seen {
+			t.Fatalf("expected in-range object %s to be ingested", object.key)
+		}
+	}
+	seen, err := db.store.IsObjectIngested(ctx, objects[2].key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen {
+		t.Fatalf("object at exclusive end %s was ingested", objects[2].key)
+	}
+	pairs, err := db.store.GetNodePairAggregates(ctx, base, end)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pairs) != 1 || pairs[0].TxBytes != 30 || pairs[0].FlowCount != 2 {
+		t.Fatalf("paginated aggregate = %+v, want 30 bytes and two flows", pairs)
+	}
+}
+
+func TestObjectStoreContinuesAfterMalformedCompressedObject(t *testing.T) {
+	base := time.Date(2026, 5, 8, 13, 0, 0, 0, time.UTC)
+	badKey := "network/2026/05/08/a/2026-05-08-13-00-00.ndjson.zstd"
+	goodKey := "network/2026/05/08/b/2026-05-08-13-30-00.ndjson.gz"
+	source, server := newTestObjectStore(t, []testObject{
+		{key: badKey, body: []byte("this is not zstd")},
+		compressedTestFlowObject(t, goodKey, "node-good", base.Add(30*time.Minute), 20, ".gz"),
+	}, 10)
+	defer server.Close()
+	poller, db := newObjectStoreTestPoller(t, source, 10)
+	ctx := context.Background()
+	err := poller.pollObjectStore(ctx, base, base.Add(time.Hour))
+	if err == nil || !strings.Contains(err.Error(), badKey) {
+		t.Fatalf("malformed compression error = %v, want error naming %s", err, badKey)
+	}
+	seen, err := db.store.IsObjectIngested(ctx, goodKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !seen {
+		t.Fatalf("expected valid compressed object %s to be ingested", goodKey)
+	}
+	pairs, err := db.store.GetNodePairAggregates(ctx, base, base.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pairs) != 1 || pairs[0].TxBytes != 20 {
+		t.Fatalf("aggregate after malformed compression = %+v, want valid object traffic only", pairs)
+	}
 }
 
 func TestObjectStorePollCapsObjectsAndUsesDeterministicEqualTimestampOrder(t *testing.T) {

--- a/backend/internal/services/poller.go
+++ b/backend/internal/services/poller.go
@@ -80,6 +80,25 @@ func NewPoller(tsService *TailscaleService, store database.Store, config PollerC
 	}
 }
 
+func (c PollerConfig) validate() error {
+	if c.PollInterval <= 0 {
+		return fmt.Errorf("poll interval must be positive")
+	}
+	if c.InitialBackfill <= 0 {
+		return fmt.Errorf("initial backfill must be positive")
+	}
+	if c.Retention < 0 {
+		return fmt.Errorf("retention must not be negative")
+	}
+	if c.CleanupInterval <= 0 {
+		return fmt.Errorf("cleanup interval must be positive")
+	}
+	if c.DeviceCacheRefresh <= 0 {
+		return fmt.Errorf("device cache refresh interval must be positive")
+	}
+	return nil
+}
+
 func (p *Poller) ConfigureObjectStore(source *ObjectStoreSource) {
 	p.objectStore = source
 	if source != nil {
@@ -91,6 +110,9 @@ func (p *Poller) ConfigureObjectStore(source *ObjectStoreSource) {
 func (p *Poller) Start(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if err := p.config.validate(); err != nil {
+		return fmt.Errorf("invalid poller configuration: %w", err)
 	}
 
 	p.mu.Lock()
@@ -311,8 +333,9 @@ func (p *Poller) refreshDeviceCache(ctx context.Context) error {
 	if p.store != nil {
 		nodeMetadata, err := p.store.GetNodeMetadata(ctx)
 		if err != nil {
-			log.Printf("Warning: node metadata cache hydration failed: %v", err)
-		} else if len(nodeMetadata) > 0 {
+			return fmt.Errorf("node metadata cache hydration failed: %w", err)
+		}
+		if len(nodeMetadata) > 0 {
 			p.deviceCache.UpsertNodeMetadata(nodeMetadata)
 		}
 	}

--- a/backend/internal/services/poller.go
+++ b/backend/internal/services/poller.go
@@ -380,12 +380,9 @@ func (p *Poller) poll(ctx context.Context) error {
 }
 
 func (p *Poller) pollObjectStore(ctx context.Context, start, end time.Time) error {
-	objects, flows, lastProcessed, err := p.objectStore.Poll(ctx, p, start, end)
-	if err != nil {
-		return err
-	}
+	objects, flows, lastProcessed, pollErr := p.objectStore.Poll(ctx, p, start, end)
 
-	if objects == 0 {
+	if objects == 0 && pollErr == nil {
 		// Move the cursor forward when no object exists yet. Object-store polling
 		// still applies a lookback and an ingested-object guard on the next pass.
 		lastProcessed = end
@@ -398,6 +395,9 @@ func (p *Poller) pollObjectStore(ctx context.Context, start, end time.Time) erro
 		if err := p.store.UpdatePollState(ctx, lastProcessed); err != nil {
 			return err
 		}
+	}
+	if pollErr != nil {
+		return pollErr
 	}
 
 	p.mu.Lock()

--- a/backend/internal/services/poller.go
+++ b/backend/internal/services/poller.go
@@ -238,7 +238,7 @@ func (p *Poller) run(ctx context.Context, stopChan <-chan struct{}, doneChan cha
 		return
 	}
 
-	if p.tsService != nil {
+	if p.canRefreshDeviceCache() {
 		if err := p.refreshDeviceCache(ctx); err != nil && ctx.Err() == nil {
 			log.Printf("Warning: initial device cache refresh failed: %v", err)
 		}
@@ -284,7 +284,7 @@ func (p *Poller) run(ctx context.Context, stopChan <-chan struct{}, doneChan cha
 			return
 		case <-triggerChan:
 			// Manual trigger — same logic as scheduled poll
-			if p.deviceCache.NeedsRefresh(p.config.DeviceCacheRefresh) {
+			if p.canRefreshDeviceCache() && p.deviceCache.NeedsRefresh(p.config.DeviceCacheRefresh) {
 				if err := p.refreshDeviceCache(ctx); err != nil {
 					log.Printf("Warning: device cache refresh failed: %v", err)
 				}
@@ -299,7 +299,7 @@ func (p *Poller) run(ctx context.Context, stopChan <-chan struct{}, doneChan cha
 			}
 		case <-pollTicker.C:
 			// Refresh device cache if stale
-			if p.deviceCache.NeedsRefresh(p.config.DeviceCacheRefresh) {
+			if p.canRefreshDeviceCache() && p.deviceCache.NeedsRefresh(p.config.DeviceCacheRefresh) {
 				if err := p.refreshDeviceCache(ctx); err != nil {
 					log.Printf("Warning: device cache refresh failed: %v", err)
 					p.mu.Lock()
@@ -322,6 +322,10 @@ func (p *Poller) run(ctx context.Context, stopChan <-chan struct{}, doneChan cha
 			}
 		}
 	}
+}
+
+func (p *Poller) canRefreshDeviceCache() bool {
+	return p != nil && p.tsService != nil && p.tsService.HasCredentials()
 }
 
 func (p *Poller) refreshDeviceCache(ctx context.Context) error {

--- a/backend/internal/services/poller.go
+++ b/backend/internal/services/poller.go
@@ -54,6 +54,7 @@ type Poller struct {
 	stopChan    chan struct{}
 	doneChan    chan struct{}
 	triggerChan chan struct{}
+	cancel      context.CancelFunc
 
 	// Stats
 	lastPollTime       time.Time
@@ -88,6 +89,10 @@ func (p *Poller) ConfigureObjectStore(source *ObjectStoreSource) {
 
 // Start begins the background polling loop
 func (p *Poller) Start(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	p.mu.Lock()
 	if p.running {
 		p.mu.Unlock()
@@ -98,19 +103,24 @@ func (p *Poller) Start(ctx context.Context) error {
 	p.stopChan = make(chan struct{})
 	p.doneChan = make(chan struct{})
 	p.triggerChan = make(chan struct{}, 1)
+	stopChan := p.stopChan
+	doneChan := p.doneChan
+	triggerChan := p.triggerChan
+	runCtx, cancel := context.WithCancel(ctx)
+	p.cancel = cancel
 	p.mu.Unlock()
 
 	log.Printf("Starting background poller (backend: %s, interval: %v, retention: %v)",
 		p.config.FlowBackend, p.config.PollInterval, p.config.Retention)
 
-	// Initial device cache refresh
-	if err := p.refreshDeviceCache(ctx); err != nil {
+	// Keep the initial device refresh synchronous for startup callers, but run it
+	// under the owned context so a concurrent Stop can cancel it.
+	if err := p.refreshDeviceCache(runCtx); err != nil && runCtx.Err() == nil {
 		log.Printf("Warning: initial device cache refresh failed: %v", err)
 	}
 
-	// Start background goroutine (initial poll happens asynchronously
-	// so the server can start accepting requests immediately)
-	go p.run(ctx)
+	// Start the background goroutine. The initial poll happens asynchronously.
+	go p.run(runCtx, stopChan, doneChan, triggerChan)
 
 	return nil
 }
@@ -125,9 +135,14 @@ func (p *Poller) Stop() {
 	p.running = false
 	stopChan := p.stopChan
 	doneChan := p.doneChan
+	cancel := p.cancel
 	p.stopChan = nil
+	p.cancel = nil
 	p.mu.Unlock()
 
+	if cancel != nil {
+		cancel()
+	}
 	if stopChan != nil {
 		close(stopChan)
 	}
@@ -171,28 +186,34 @@ func (p *Poller) GetRollingCache() *RollingWindowCache {
 // TriggerPoll signals the background loop to poll immediately.
 // Non-blocking: if a trigger is already pending, this is a no-op.
 func (p *Poller) TriggerPoll() {
+	p.mu.RLock()
+	triggerChan := p.triggerChan
+	p.mu.RUnlock()
+	if triggerChan == nil {
+		return
+	}
 	select {
-	case p.triggerChan <- struct{}{}:
+	case triggerChan <- struct{}{}:
 	default:
 	}
 }
 
-func (p *Poller) run(ctx context.Context) {
-	// Capture channels at start to avoid race with Stop() setting them to nil
-	p.mu.RLock()
-	stopChan := p.stopChan
-	doneChan := p.doneChan
-	p.mu.RUnlock()
-
+func (p *Poller) run(ctx context.Context, stopChan <-chan struct{}, doneChan chan<- struct{}, triggerChan <-chan struct{}) {
 	defer close(doneChan)
+	if ctx.Err() != nil {
+		return
+	}
 
 	// Run cleanup before initial poll to purge any stale raw flow logs from prior runs
-	if err := p.cleanup(ctx); err != nil {
+	if err := p.cleanup(ctx); err != nil && ctx.Err() == nil {
 		log.Printf("Pre-poll cleanup failed: %v", err)
+	}
+	if ctx.Err() != nil {
+		return
 	}
 
 	// Initial poll (runs asynchronously so the server isn't blocked)
-	if err := p.poll(ctx); err != nil {
+	if err := p.poll(ctx); err != nil && ctx.Err() == nil {
 		log.Printf("Initial poll failed: %v", err)
 		p.mu.Lock()
 		p.pollErrors++
@@ -213,7 +234,7 @@ func (p *Poller) run(ctx context.Context) {
 			return
 		case <-stopChan:
 			return
-		case <-p.triggerChan:
+		case <-triggerChan:
 			// Manual trigger — same logic as scheduled poll
 			if p.deviceCache.NeedsRefresh(p.config.DeviceCacheRefresh) {
 				if err := p.refreshDeviceCache(ctx); err != nil {

--- a/backend/internal/services/poller.go
+++ b/backend/internal/services/poller.go
@@ -256,7 +256,7 @@ func (p *Poller) run(ctx context.Context) {
 }
 
 func (p *Poller) refreshDeviceCache(ctx context.Context) error {
-	devicesResp, err := p.tsService.GetDevices()
+	devicesResp, err := p.tsService.GetDevicesWithContext(ctx)
 	if err != nil {
 		return err
 	}
@@ -319,7 +319,13 @@ func (p *Poller) pollObjectStore(ctx context.Context, start, end time.Time) erro
 		// Move the cursor forward when no object exists yet. Object-store polling
 		// still applies a lookback and an ingested-object guard on the next pass.
 		lastProcessed = end
-		if err := p.store.UpdatePollState(ctx, end); err != nil {
+	}
+	// CommitObjectIngest advances the cursor for newly ingested objects, but
+	// already-ingested objects do not need another aggregate commit. Persist the
+	// source cursor here as well so a restart does not repeatedly scan an old
+	// range when a poll only encounters objects already seen.
+	if !lastProcessed.IsZero() {
+		if err := p.store.UpdatePollState(ctx, lastProcessed); err != nil {
 			return err
 		}
 	}
@@ -378,7 +384,7 @@ func (p *Poller) pollChunked(ctx context.Context, start, end time.Time) error {
 // pollRange fetches and commits logs for a single time range.
 func (p *Poller) pollRange(ctx context.Context, start, end time.Time) error {
 	// Fetch logs from Tailscale API
-	logsResp, err := p.tsService.GetNetworkLogs(
+	logsResp, err := p.tsService.GetNetworkLogsWithContext(ctx,
 		start.Format(time.RFC3339),
 		end.Format(time.RFC3339),
 	)

--- a/backend/internal/services/poller.go
+++ b/backend/internal/services/poller.go
@@ -113,13 +113,9 @@ func (p *Poller) Start(ctx context.Context) error {
 	log.Printf("Starting background poller (backend: %s, interval: %v, retention: %v)",
 		p.config.FlowBackend, p.config.PollInterval, p.config.Retention)
 
-	// Keep the initial device refresh synchronous for startup callers, but run it
-	// under the owned context so a concurrent Stop can cancel it.
-	if err := p.refreshDeviceCache(runCtx); err != nil && runCtx.Err() == nil {
-		log.Printf("Warning: initial device cache refresh failed: %v", err)
-	}
-
-	// Start the background goroutine. The initial poll happens asynchronously.
+	// Run all network work in the background. In particular, device refreshes can
+	// take several minutes when the Tailscale API is unavailable and must not
+	// block the HTTP server from starting.
 	go p.run(runCtx, stopChan, doneChan, triggerChan)
 
 	return nil
@@ -132,19 +128,21 @@ func (p *Poller) Stop() {
 		p.mu.Unlock()
 		return
 	}
-	p.running = false
 	stopChan := p.stopChan
 	doneChan := p.doneChan
 	cancel := p.cancel
-	p.stopChan = nil
-	p.cancel = nil
+	// Only the first concurrent Stop closes the channel. Keep running=true
+	// until run has actually exited so a concurrent Start cannot overlap two
+	// poll loops.
+	if stopChan != nil {
+		close(stopChan)
+		p.stopChan = nil
+	}
+	p.triggerChan = nil
 	p.mu.Unlock()
 
 	if cancel != nil {
 		cancel()
-	}
-	if stopChan != nil {
-		close(stopChan)
 	}
 	if doneChan != nil {
 		<-doneChan
@@ -198,9 +196,37 @@ func (p *Poller) TriggerPoll() {
 	}
 }
 
-func (p *Poller) run(ctx context.Context, stopChan <-chan struct{}, doneChan chan<- struct{}, triggerChan <-chan struct{}) {
-	defer close(doneChan)
+func (p *Poller) run(ctx context.Context, stopChan <-chan struct{}, doneChan chan struct{}, triggerChan <-chan struct{}) {
+	defer func() {
+		p.mu.Lock()
+		// The channel identity protects a newer run if lifecycle methods are
+		// ever extended to permit a restart while an old run is unwinding.
+		if p.doneChan == doneChan {
+			p.running = false
+			p.doneChan = nil
+			p.stopChan = nil
+			p.triggerChan = nil
+			p.cancel = nil
+		}
+		p.mu.Unlock()
+		close(doneChan)
+	}()
+
 	if ctx.Err() != nil {
+		return
+	}
+
+	if p.tsService != nil {
+		if err := p.refreshDeviceCache(ctx); err != nil && ctx.Err() == nil {
+			log.Printf("Warning: initial device cache refresh failed: %v", err)
+		}
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	// A poller without a store is not useful, but allowing its lifecycle to
+	// settle cleanly keeps shutdown safe for callers that only use its caches.
+	if p.store == nil || p.tsService == nil && p.objectStore == nil {
 		return
 	}
 

--- a/backend/internal/services/poller.go
+++ b/backend/internal/services/poller.go
@@ -289,7 +289,7 @@ func (p *Poller) run(ctx context.Context, stopChan <-chan struct{}, doneChan cha
 					log.Printf("Warning: device cache refresh failed: %v", err)
 				}
 			}
-			if err := p.poll(ctx); err != nil {
+			if err := p.poll(ctx); err != nil && ctx.Err() == nil {
 				log.Printf("Triggered poll failed: %v", err)
 				p.mu.Lock()
 				p.pollErrors++
@@ -308,7 +308,7 @@ func (p *Poller) run(ctx context.Context, stopChan <-chan struct{}, doneChan cha
 				}
 			}
 
-			if err := p.poll(ctx); err != nil {
+			if err := p.poll(ctx); err != nil && ctx.Err() == nil {
 				log.Printf("Poll failed: %v", err)
 				p.mu.Lock()
 				p.pollErrors++
@@ -415,7 +415,10 @@ func (p *Poller) pollObjectStore(ctx context.Context, start, end time.Time) erro
 // each chunk independently so that progress is saved on partial failure.
 func (p *Poller) pollChunked(ctx context.Context, start, end time.Time) error {
 	totalRange := end.Sub(start)
-	numChunks := int(totalRange/maxPollChunk) + 1
+	numChunks := int(totalRange / maxPollChunk)
+	if totalRange%maxPollChunk != 0 {
+		numChunks++
+	}
 	log.Printf("Large time range (%v), splitting into %d chunks of %v", totalRange.Round(time.Second), numChunks, maxPollChunk)
 
 	cursor := start
@@ -430,9 +433,11 @@ func (p *Poller) pollChunked(ctx context.Context, start, end time.Time) error {
 			log.Printf("Chunk %d/%d failed (%v to %v): %v — stopping backfill, will resume next poll",
 				chunksCompleted+1, numChunks,
 				cursor.Format(time.RFC3339), chunkEnd.Format(time.RFC3339), err)
-			// Return nil so the poller doesn't count this as a full failure;
-			// progress up to the last successful chunk is already committed.
-			return nil
+			// Progress up to the last successful chunk is already committed, so
+			// the next poll can resume from there. Still propagate the failure so
+			// poller status and operators can distinguish an incomplete backfill
+			// from a successful one.
+			return fmt.Errorf("poll chunk %d/%d failed: %w", chunksCompleted+1, numChunks, err)
 		}
 
 		chunksCompleted++
@@ -442,7 +447,7 @@ func (p *Poller) pollChunked(ctx context.Context, start, end time.Time) error {
 		select {
 		case <-ctx.Done():
 			log.Printf("Backfill interrupted after %d/%d chunks", chunksCompleted, numChunks)
-			return nil
+			return ctx.Err()
 		default:
 		}
 	}

--- a/backend/internal/services/poller_test.go
+++ b/backend/internal/services/poller_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/rajsinghtech/tsflow/backend/internal/config"
+	"github.com/rajsinghtech/tsflow/backend/internal/database"
 )
 
 func TestPollerStopCancelsInitialDeviceRefresh(t *testing.T) {
@@ -150,5 +152,48 @@ func TestPollerStartRejectsUnsafeIntervals(t *testing.T) {
 				t.Fatal("Start() unexpectedly accepted unsafe configuration")
 			}
 		})
+	}
+}
+
+func TestPollChunkedPropagatesFailureAfterCommittedProgress(t *testing.T) {
+	start := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	failingChunkStart := start.Add(maxPollChunk)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("start") == failingChunkStart.Format(time.RFC3339) {
+			http.Error(w, "upstream failure", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"logs":[]}`))
+	}))
+	defer server.Close()
+
+	store, err := database.NewSQLiteStore(t.TempDir() + "/poller.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	service := NewTailscaleService(&config.Config{
+		TailscaleAPIURL:  server.URL,
+		TailscaleTailnet: "example.com",
+	})
+	poller := NewPoller(service, store, DefaultPollerConfig())
+	end := start.Add(2 * maxPollChunk)
+
+	err = poller.pollChunked(context.Background(), start, end)
+	if err == nil || !strings.Contains(err.Error(), "poll chunk 2/2 failed") {
+		t.Fatalf("pollChunked error = %v, want second chunk failure", err)
+	}
+
+	state, err := store.GetPollState(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.LastPollEnd.Equal(failingChunkStart) {
+		t.Fatalf("poll cursor = %v, want committed first-chunk end %v", state.LastPollEnd, failingChunkStart)
 	}
 }

--- a/backend/internal/services/poller_test.go
+++ b/backend/internal/services/poller_test.go
@@ -130,6 +130,83 @@ func TestPollerS3OnlySkipsUnauthenticatedDeviceRefresh(t *testing.T) {
 	}
 }
 
+func TestPollerS3OnlyStartIngestsCompressedObjectAndStops(t *testing.T) {
+	apiRequests := make(chan struct{}, 1)
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiRequests <- struct{}{}
+		http.Error(w, "unexpected API request", http.StatusUnauthorized)
+	}))
+	defer apiServer.Close()
+
+	loggedAt := time.Now().UTC().Add(-time.Minute)
+	key := "network/" + loggedAt.Format("2006/01/02/2006-01-02-15-04-05") + ".ndjson.gz"
+	source, objectServer := newTestObjectStore(t, []testObject{
+		compressedTestFlowObject(t, key, "node-s3", loggedAt, 37, ".gz"),
+	}, 10)
+	defer objectServer.Close()
+
+	service := NewTailscaleService(&config.Config{
+		TailscaleAPIURL:  apiServer.URL,
+		TailscaleTailnet: "example.com",
+	})
+	if service.HasCredentials() {
+		t.Fatal("test Tailscale service unexpectedly has credentials")
+	}
+	poller, db := newObjectStoreTestPollerWithService(t, source, 10, service)
+	poller.config.InitialBackfill = time.Hour
+	poller.config.PollInterval = time.Hour
+	poller.config.CleanupInterval = time.Hour
+	poller.config.Retention = 0
+
+	if err := poller.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	deadline := time.NewTimer(2 * time.Second)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer deadline.Stop()
+	defer ticker.Stop()
+	for {
+		seen, err := db.store.IsObjectIngested(ctx, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if seen {
+			break
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatal("S3-only poller did not ingest the compressed object")
+		}
+	}
+
+	pairs, err := db.store.GetNodePairAggregates(ctx, loggedAt.Add(-time.Minute), loggedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pairs) != 1 || pairs[0].TxBytes != 37 || pairs[0].FlowCount != 1 {
+		t.Fatalf("S3-only aggregate = %+v, want one flow with 37 transmitted bytes", pairs)
+	}
+	select {
+	case <-apiRequests:
+		t.Fatal("S3-only poller attempted an unauthenticated Tailscale API request")
+	default:
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		poller.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("S3-only poller Stop did not complete")
+	}
+}
+
 func TestPollerStartWithCanceledContextStopsCleanly(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/backend/internal/services/poller_test.go
+++ b/backend/internal/services/poller_test.go
@@ -94,6 +94,42 @@ func TestPollerStartDoesNotWaitForDeviceRefresh(t *testing.T) {
 	poller.Stop()
 }
 
+func TestPollerS3OnlySkipsUnauthenticatedDeviceRefresh(t *testing.T) {
+	requests := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- struct{}{}
+		http.Error(w, "unexpected API request", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	service := NewTailscaleService(&config.Config{
+		TailscaleAPIURL:  server.URL,
+		TailscaleTailnet: "example.com",
+	})
+	if service.HasCredentials() {
+		t.Fatal("service without API credentials reported usable credentials")
+	}
+
+	poller := NewPoller(service, nil, PollerConfig{
+		PollInterval:       time.Hour,
+		InitialBackfill:    time.Hour,
+		Retention:          0,
+		CleanupInterval:    time.Hour,
+		DeviceCacheRefresh: time.Hour,
+		FlowBackend:        "s3",
+	})
+	if err := poller.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	poller.Stop()
+
+	select {
+	case <-requests:
+		t.Fatal("S3-only poller attempted an unauthenticated device refresh")
+	default:
+	}
+}
+
 func TestPollerStartWithCanceledContextStopsCleanly(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/backend/internal/services/poller_test.go
+++ b/backend/internal/services/poller_test.go
@@ -131,3 +131,24 @@ func TestPollerStopIsSafeWhenCalledConcurrently(t *testing.T) {
 		}
 	}
 }
+
+func TestPollerStartRejectsUnsafeIntervals(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		edit func(*PollerConfig)
+	}{
+		{name: "zero poll interval", edit: func(c *PollerConfig) { c.PollInterval = 0 }},
+		{name: "negative cleanup interval", edit: func(c *PollerConfig) { c.CleanupInterval = -time.Second }},
+		{name: "negative backfill", edit: func(c *PollerConfig) { c.InitialBackfill = -time.Second }},
+		{name: "zero backfill", edit: func(c *PollerConfig) { c.InitialBackfill = 0 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultPollerConfig()
+			tc.edit(&cfg)
+			poller := NewPoller(nil, nil, cfg)
+			if err := poller.Start(context.Background()); err == nil {
+				t.Fatal("Start() unexpectedly accepted unsafe configuration")
+			}
+		})
+	}
+}

--- a/backend/internal/services/poller_test.go
+++ b/backend/internal/services/poller_test.go
@@ -55,3 +55,79 @@ func TestPollerStopCancelsInitialDeviceRefresh(t *testing.T) {
 		t.Fatal("poller Start did not return after cancellation")
 	}
 }
+
+func TestPollerStartDoesNotWaitForDeviceRefresh(t *testing.T) {
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	service := NewTailscaleService(&config.Config{
+		TailscaleAPIURL:  server.URL,
+		TailscaleAPIKey:  "test-key",
+		TailscaleTailnet: "example.com",
+	})
+	poller := NewPoller(service, nil, DefaultPollerConfig())
+
+	startReturned := make(chan error, 1)
+	go func() { startReturned <- poller.Start(context.Background()) }()
+	select {
+	case err := <-startReturned:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		poller.Stop()
+		t.Fatal("poller Start waited for the device refresh")
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		poller.Stop()
+		t.Fatal("background device refresh did not start")
+	}
+	poller.Stop()
+}
+
+func TestPollerStartWithCanceledContextStopsCleanly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+
+	if err := poller.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if running, ok := poller.Stats()["running"].(bool); ok && !running {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("poller remained running after startup context cancellation")
+}
+
+func TestPollerStopIsSafeWhenCalledConcurrently(t *testing.T) {
+	poller := NewPoller(nil, nil, DefaultPollerConfig())
+	if err := poller.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	stopped := make(chan struct{}, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			poller.Stop()
+			stopped <- struct{}{}
+		}()
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case <-stopped:
+		case <-time.After(time.Second):
+			t.Fatal("concurrent poller Stop did not return")
+		}
+	}
+}

--- a/backend/internal/services/poller_test.go
+++ b/backend/internal/services/poller_test.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rajsinghtech/tsflow/backend/internal/config"
+)
+
+func TestPollerStopCancelsInitialDeviceRefresh(t *testing.T) {
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	service := NewTailscaleService(&config.Config{
+		TailscaleAPIURL:  server.URL,
+		TailscaleAPIKey:  "test-key",
+		TailscaleTailnet: "example.com",
+	})
+	poller := NewPoller(service, nil, DefaultPollerConfig())
+	startedPoller := make(chan error, 1)
+	go func() { startedPoller <- poller.Start(context.Background()) }()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		poller.Stop()
+		t.Fatal("initial device refresh did not reach test server")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		poller.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("poller Stop did not cancel the in-flight refresh")
+	}
+
+	select {
+	case err := <-startedPoller:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("poller Start did not return after cancellation")
+	}
+}

--- a/backend/internal/services/rolling_cache.go
+++ b/backend/internal/services/rolling_cache.go
@@ -20,8 +20,9 @@ type RollingWindowCache struct {
 
 	// Unique node pairs contributing to network-wide traffic stats by bucket.
 	// Keeping the set avoids undercounting when separate polls or traffic types
-	// contain disjoint pairs.
-	trafficStatPairs map[int64]map[string]struct{}
+	// contain disjoint pairs. The pair value is kept as two fields so endpoint
+	// IDs containing a delimiter cannot collide.
+	trafficStatPairs map[int64]map[trafficPairKey]struct{}
 
 	// Total bandwidth by minute bucket
 	bandwidth map[int64]*database.BandwidthBucket
@@ -39,7 +40,7 @@ type RollingWindowCache struct {
 func NewRollingWindowCache(maxAge time.Duration) *RollingWindowCache {
 	return &RollingWindowCache{
 		nodePairs:        make(map[int64][]database.NodePairAggregate),
-		trafficStatPairs: make(map[int64]map[string]struct{}),
+		trafficStatPairs: make(map[int64]map[trafficPairKey]struct{}),
 		bandwidth:        make(map[int64]*database.BandwidthBucket),
 		nodeBandwidth:    make(map[int64]map[string]*database.NodeBandwidth),
 		trafficStats:     make(map[int64]*database.TrafficStats),
@@ -60,9 +61,12 @@ func (c *RollingWindowCache) Update(
 	// Add node pairs by bucket, deduplicating by (src, dst, trafficType)
 	for _, np := range nodePairs {
 		if c.trafficStatPairs[np.Bucket] == nil {
-			c.trafficStatPairs[np.Bucket] = make(map[string]struct{})
+			c.trafficStatPairs[np.Bucket] = make(map[trafficPairKey]struct{})
 		}
-		c.trafficStatPairs[np.Bucket][np.SrcNodeID+"|"+np.DstNodeID] = struct{}{}
+		c.trafficStatPairs[np.Bucket][trafficPairKey{
+			srcNodeID: np.SrcNodeID,
+			dstNodeID: np.DstNodeID,
+		}] = struct{}{}
 
 		existing := c.nodePairs[np.Bucket]
 		found := false

--- a/backend/internal/services/rolling_cache.go
+++ b/backend/internal/services/rolling_cache.go
@@ -18,6 +18,11 @@ type RollingWindowCache struct {
 	// Node pair aggregates by minute bucket
 	nodePairs map[int64][]database.NodePairAggregate
 
+	// Unique node pairs contributing to network-wide traffic stats by bucket.
+	// Keeping the set avoids undercounting when separate polls or traffic types
+	// contain disjoint pairs.
+	trafficStatPairs map[int64]map[string]struct{}
+
 	// Total bandwidth by minute bucket
 	bandwidth map[int64]*database.BandwidthBucket
 
@@ -33,11 +38,12 @@ type RollingWindowCache struct {
 
 func NewRollingWindowCache(maxAge time.Duration) *RollingWindowCache {
 	return &RollingWindowCache{
-		nodePairs:     make(map[int64][]database.NodePairAggregate),
-		bandwidth:     make(map[int64]*database.BandwidthBucket),
-		nodeBandwidth: make(map[int64]map[string]*database.NodeBandwidth),
-		trafficStats:  make(map[int64]*database.TrafficStats),
-		maxAge:        maxAge,
+		nodePairs:        make(map[int64][]database.NodePairAggregate),
+		trafficStatPairs: make(map[int64]map[string]struct{}),
+		bandwidth:        make(map[int64]*database.BandwidthBucket),
+		nodeBandwidth:    make(map[int64]map[string]*database.NodeBandwidth),
+		trafficStats:     make(map[int64]*database.TrafficStats),
+		maxAge:           maxAge,
 	}
 }
 
@@ -53,6 +59,11 @@ func (c *RollingWindowCache) Update(
 
 	// Add node pairs by bucket, deduplicating by (src, dst, trafficType)
 	for _, np := range nodePairs {
+		if c.trafficStatPairs[np.Bucket] == nil {
+			c.trafficStatPairs[np.Bucket] = make(map[string]struct{})
+		}
+		c.trafficStatPairs[np.Bucket][np.SrcNodeID+"|"+np.DstNodeID] = struct{}{}
+
 		existing := c.nodePairs[np.Bucket]
 		found := false
 		for i := range existing {
@@ -124,12 +135,21 @@ func (c *RollingWindowCache) Update(
 			existing.SubnetBytes += ts.SubnetBytes
 			existing.PhysicalBytes += ts.PhysicalBytes
 			existing.TotalFlows += ts.TotalFlows
-			if ts.UniquePairs > existing.UniquePairs {
-				existing.UniquePairs = ts.UniquePairs // max, consistent with DB upsert
+			if pairs := c.trafficStatPairs[ts.Bucket]; len(pairs) > 0 {
+				if pairCount := int64(len(pairs)); pairCount > existing.UniquePairs {
+					existing.UniquePairs = pairCount
+				}
+			} else if ts.UniquePairs > existing.UniquePairs {
+				existing.UniquePairs = ts.UniquePairs
 			}
 			existing.TopPorts = mergePortJSON(existing.TopPorts, ts.TopPorts)
 		} else {
 			copied := ts
+			if pairs := c.trafficStatPairs[ts.Bucket]; len(pairs) > 0 {
+				if pairCount := int64(len(pairs)); pairCount > copied.UniquePairs {
+					copied.UniquePairs = pairCount
+				}
+			}
 			c.trafficStats[ts.Bucket] = &copied
 		}
 	}
@@ -145,6 +165,12 @@ func (c *RollingWindowCache) prune() {
 	for bucket := range c.nodePairs {
 		if bucket < cutoff {
 			delete(c.nodePairs, bucket)
+		}
+	}
+
+	for bucket := range c.trafficStatPairs {
+		if bucket < cutoff {
+			delete(c.trafficStatPairs, bucket)
 		}
 	}
 
@@ -181,6 +207,18 @@ func (c *RollingWindowCache) GetNodePairs(start, end time.Time) []database.NodeP
 			result = append(result, pairs...)
 		}
 	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Bucket != result[j].Bucket {
+			return result[i].Bucket < result[j].Bucket
+		}
+		if result[i].SrcNodeID != result[j].SrcNodeID {
+			return result[i].SrcNodeID < result[j].SrcNodeID
+		}
+		if result[i].DstNodeID != result[j].DstNodeID {
+			return result[i].DstNodeID < result[j].DstNodeID
+		}
+		return result[i].TrafficType < result[j].TrafficType
+	})
 
 	return result
 }

--- a/backend/internal/services/rolling_cache.go
+++ b/backend/internal/services/rolling_cache.go
@@ -68,6 +68,8 @@ func (c *RollingWindowCache) Update(
 		found := false
 		for i := range existing {
 			if existing[i].SrcNodeID == np.SrcNodeID && existing[i].DstNodeID == np.DstNodeID && existing[i].TrafficType == np.TrafficType {
+				existingDirectional := existing[i].DirectionalPorts
+				incomingDirectional := np.DirectionalPorts
 				existing[i].TxBytes += np.TxBytes
 				existing[i].RxBytes += np.RxBytes
 				existing[i].TxPkts += np.TxPkts
@@ -81,6 +83,20 @@ func (c *RollingWindowCache) Update(
 				)
 				existing[i].Protocols = protocolJSONFromBytes(existing[i].ProtocolBytes, existing[i].Protocols, np.Protocols)
 				existing[i].Ports = mergePortJSON(existing[i].Ports, np.Ports)
+				if existingDirectional && incomingDirectional {
+					existing[i].TxProtocolBytes = mergeDirectionalProtocolByteJSON(existing[i].TxProtocolBytes, np.TxProtocolBytes)
+					existing[i].RxProtocolBytes = mergeDirectionalProtocolByteJSON(existing[i].RxProtocolBytes, np.RxProtocolBytes)
+					existing[i].TxPorts = mergePortJSON(existing[i].TxPorts, np.TxPorts)
+					existing[i].RxPorts = mergePortJSON(existing[i].RxPorts, np.RxPorts)
+				} else {
+					// A legacy contribution has no reliable direction metadata. Keep
+					// the cache response on the legacy path for the whole pair.
+					existing[i].DirectionalPorts = false
+					existing[i].TxProtocolBytes = "{}"
+					existing[i].RxProtocolBytes = "{}"
+					existing[i].TxPorts = "[]"
+					existing[i].RxPorts = "[]"
+				}
 				found = true
 				break
 			}
@@ -305,7 +321,14 @@ func cacheWindowCovers(now time.Time, maxAge time.Duration, start, end time.Time
 	if start.Before(now.Add(-maxAge)) || end.After(now.Add(time.Minute)) {
 		return false
 	}
-	firstBucket := (start.Unix() / 60) * 60
+	// Getters use the exact Unix-second range (`bucket >= start.Unix()`), so a
+	// query beginning partway through a minute cannot be covered by the bucket
+	// that began before it. Start at the first bucket the getter can return.
+	startUnix := start.Unix()
+	firstBucket := (startUnix / 60) * 60
+	if firstBucket < startUnix {
+		firstBucket += 60
+	}
 	lastBucket := ((end.Unix() - 1) / 60) * 60
 	if lastBucket < firstBucket {
 		return false
@@ -395,6 +418,27 @@ func mergeProtocolByteJSON(existing, incoming, existingProtocols, incomingProtoc
 	}
 	add(existing, existingProtocols, existingTotal)
 	add(incoming, incomingProtocols, incomingTotal)
+	encoded, err := json.Marshal(merged)
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}
+
+func mergeDirectionalProtocolByteJSON(existing, incoming string) string {
+	merged := make(map[int]int64)
+	for _, raw := range []string{existing, incoming} {
+		var values map[string]int64
+		if json.Unmarshal([]byte(raw), &values) != nil {
+			continue
+		}
+		for rawProtocol, bytes := range values {
+			var protocol int
+			if _, err := fmt.Sscanf(rawProtocol, "%d", &protocol); err == nil {
+				merged[protocol] += bytes
+			}
+		}
+	}
 	encoded, err := json.Marshal(merged)
 	if err != nil {
 		return "{}"

--- a/backend/internal/services/rolling_cache.go
+++ b/backend/internal/services/rolling_cache.go
@@ -132,6 +132,7 @@ func (c *RollingWindowCache) Update(
 			existing.UDPBytes += ts.UDPBytes
 			existing.OtherProtoBytes += ts.OtherProtoBytes
 			existing.VirtualBytes += ts.VirtualBytes
+			existing.ExitBytes += ts.ExitBytes
 			existing.SubnetBytes += ts.SubnetBytes
 			existing.PhysicalBytes += ts.PhysicalBytes
 			existing.TotalFlows += ts.TotalFlows

--- a/backend/internal/services/rolling_cache.go
+++ b/backend/internal/services/rolling_cache.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"encoding/json"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -60,6 +62,14 @@ func (c *RollingWindowCache) Update(
 				existing[i].TxPkts += np.TxPkts
 				existing[i].RxPkts += np.RxPkts
 				existing[i].FlowCount += np.FlowCount
+				existing[i].ProtocolBytes = mergeProtocolByteJSON(
+					existing[i].ProtocolBytes, np.ProtocolBytes,
+					existing[i].Protocols, np.Protocols,
+					existing[i].TxBytes+existing[i].RxBytes-np.TxBytes-np.RxBytes,
+					np.TxBytes+np.RxBytes,
+				)
+				existing[i].Protocols = protocolJSONFromBytes(existing[i].ProtocolBytes, existing[i].Protocols, np.Protocols)
+				existing[i].Ports = mergePortJSON(existing[i].Ports, np.Ports)
 				found = true
 				break
 			}
@@ -103,7 +113,8 @@ func (c *RollingWindowCache) Update(
 		}
 	}
 
-	// Add traffic stats by bucket (additive for byte/flow counters, replace for uniquePairs/topPorts)
+	// Add traffic stats by bucket. Port counters are additive because multiple
+	// polls can contribute to the same minute bucket.
 	for _, ts := range trafficStats {
 		if existing, ok := c.trafficStats[ts.Bucket]; ok {
 			existing.TCPBytes += ts.TCPBytes
@@ -114,9 +125,9 @@ func (c *RollingWindowCache) Update(
 			existing.PhysicalBytes += ts.PhysicalBytes
 			existing.TotalFlows += ts.TotalFlows
 			if ts.UniquePairs > existing.UniquePairs {
-			existing.UniquePairs = ts.UniquePairs // max, consistent with DB upsert
-		}
-			existing.TopPorts = ts.TopPorts       // replace: latest snapshot
+				existing.UniquePairs = ts.UniquePairs // max, consistent with DB upsert
+			}
+			existing.TopPorts = mergePortJSON(existing.TopPorts, ts.TopPorts)
 		} else {
 			copied := ts
 			c.trafficStats[ts.Bucket] = &copied
@@ -166,7 +177,7 @@ func (c *RollingWindowCache) GetNodePairs(start, end time.Time) []database.NodeP
 	var result []database.NodePairAggregate
 
 	for bucket, pairs := range c.nodePairs {
-		if bucket >= startUnix && bucket <= endUnix {
+		if bucket >= startUnix && bucket < endUnix {
 			result = append(result, pairs...)
 		}
 	}
@@ -184,7 +195,7 @@ func (c *RollingWindowCache) GetBandwidth(start, end time.Time) []database.Bandw
 	var result []database.BandwidthBucket
 
 	for bucket, bw := range c.bandwidth {
-		if bucket >= startUnix && bucket <= endUnix {
+		if bucket >= startUnix && bucket < endUnix {
 			result = append(result, *bw)
 		}
 	}
@@ -207,7 +218,7 @@ func (c *RollingWindowCache) GetNodeBandwidth(start, end time.Time, nodeID strin
 	var result []database.BandwidthBucket
 
 	for bucket, nodeMap := range c.nodeBandwidth {
-		if bucket >= startUnix && bucket <= endUnix {
+		if bucket >= startUnix && bucket < endUnix {
 			if nb, ok := nodeMap[nodeID]; ok {
 				result = append(result, database.BandwidthBucket{
 					Time:    time.Unix(bucket, 0).UTC(),
@@ -236,7 +247,7 @@ func (c *RollingWindowCache) GetTrafficStats(start, end time.Time) []database.Tr
 	var result []database.TrafficStats
 
 	for bucket, ts := range c.trafficStats {
-		if bucket >= startUnix && bucket <= endUnix {
+		if bucket >= startUnix && bucket < endUnix {
 			result = append(result, *ts)
 		}
 	}
@@ -248,37 +259,190 @@ func (c *RollingWindowCache) GetTrafficStats(start, end time.Time) []database.Tr
 	return result
 }
 
-// HasDataFor returns true if the cache likely has data covering the given time range.
-// Both start and end must be within the cache window, and the cache must have
-// buckets that overlap the requested range.
-func (c *RollingWindowCache) HasDataFor(start, end time.Time) bool {
+func cacheWindowCovers(now time.Time, maxAge time.Duration, start, end time.Time, buckets map[int64]struct{}) bool {
+	if !end.After(start) || len(buckets) == 0 {
+		return false
+	}
+	if start.Before(now.Add(-maxAge)) || end.After(now.Add(time.Minute)) {
+		return false
+	}
+	firstBucket := (start.Unix() / 60) * 60
+	lastBucket := ((end.Unix() - 1) / 60) * 60
+	if lastBucket < firstBucket {
+		return false
+	}
+	for bucket := firstBucket; bucket <= lastBucket; bucket += 60 {
+		if _, ok := buckets[bucket]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *RollingWindowCache) HasNodePairDataFor(start, end time.Time) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-
-	// Check if we have any data at all
-	if len(c.bandwidth) == 0 && len(c.nodePairs) == 0 {
-		return false
-	}
-
-	// Both start and end must be within the cache window
-	cacheStart := time.Now().Add(-c.maxAge)
-	if start.Before(cacheStart) {
-		return false
-	}
-
-	// Verify we have at least one bucket in the requested range
-	startUnix := start.Unix()
-	endUnix := end.Unix()
-	for bucket := range c.bandwidth {
-		if bucket >= startUnix && bucket <= endUnix {
-			return true
-		}
-	}
+	buckets := make(map[int64]struct{}, len(c.nodePairs))
 	for bucket := range c.nodePairs {
-		if bucket >= startUnix && bucket <= endUnix {
-			return true
+		buckets[bucket] = struct{}{}
+	}
+	return cacheWindowCovers(time.Now(), c.maxAge, start, end, buckets)
+}
+
+func (c *RollingWindowCache) HasBandwidthDataFor(start, end time.Time) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	buckets := make(map[int64]struct{}, len(c.bandwidth))
+	for bucket := range c.bandwidth {
+		buckets[bucket] = struct{}{}
+	}
+	return cacheWindowCovers(time.Now(), c.maxAge, start, end, buckets)
+}
+
+func (c *RollingWindowCache) HasNodeBandwidthDataFor(start, end time.Time, nodeID string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	buckets := make(map[int64]struct{})
+	for bucket, nodes := range c.nodeBandwidth {
+		if _, ok := nodes[nodeID]; ok {
+			buckets[bucket] = struct{}{}
 		}
 	}
+	return cacheWindowCovers(time.Now(), c.maxAge, start, end, buckets)
+}
 
-	return false
+func (c *RollingWindowCache) HasTrafficStatsDataFor(start, end time.Time) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	buckets := make(map[int64]struct{}, len(c.trafficStats))
+	for bucket := range c.trafficStats {
+		buckets[bucket] = struct{}{}
+	}
+	return cacheWindowCovers(time.Now(), c.maxAge, start, end, buckets)
+}
+
+// HasDataFor is retained for callers that do not identify a dataset. It only
+// reports a hit when one complete dataset covers the range.
+func (c *RollingWindowCache) HasDataFor(start, end time.Time) bool {
+	return c.HasNodePairDataFor(start, end) || c.HasBandwidthDataFor(start, end)
+}
+
+func mergeProtocolByteJSON(existing, incoming, existingProtocols, incomingProtocols string, existingTotal, incomingTotal int64) string {
+	merged := make(map[int]int64)
+	add := func(rawBytes, rawProtocols string, total int64) {
+		var values map[string]int64
+		if json.Unmarshal([]byte(rawBytes), &values) == nil && len(values) > 0 {
+			for rawProtocol, bytes := range values {
+				var protocol int
+				if _, err := fmt.Sscanf(rawProtocol, "%d", &protocol); err == nil {
+					merged[protocol] += bytes
+				}
+			}
+			return
+		}
+		var protocols []int
+		if json.Unmarshal([]byte(rawProtocols), &protocols) != nil || len(protocols) == 0 {
+			return
+		}
+		perProtocol := total / int64(len(protocols))
+		remainder := total - perProtocol*int64(len(protocols))
+		for i, protocol := range protocols {
+			bytes := perProtocol
+			if i == 0 {
+				bytes += remainder
+			}
+			merged[protocol] += bytes
+		}
+	}
+	add(existing, existingProtocols, existingTotal)
+	add(incoming, incomingProtocols, incomingTotal)
+	encoded, err := json.Marshal(merged)
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}
+
+func protocolJSONFromBytes(rawBytes, fallbackExisting, fallbackIncoming string) string {
+	var values map[string]int64
+	if json.Unmarshal([]byte(rawBytes), &values) != nil || len(values) == 0 {
+		return mergeProtocolJSON(fallbackExisting, fallbackIncoming)
+	}
+	protocols := make([]int, 0, len(values))
+	for rawProtocol := range values {
+		var protocol int
+		if _, err := fmt.Sscanf(rawProtocol, "%d", &protocol); err == nil {
+			protocols = append(protocols, protocol)
+		}
+	}
+	sort.Slice(protocols, func(i, j int) bool {
+		left, right := values[fmt.Sprint(protocols[i])], values[fmt.Sprint(protocols[j])]
+		if left != right {
+			return left > right
+		}
+		return protocols[i] < protocols[j]
+	})
+	encoded, err := json.Marshal(protocols)
+	if err != nil {
+		return "[]"
+	}
+	return string(encoded)
+}
+
+func mergeProtocolJSON(existing, incoming string) string {
+	var values []int
+	seen := make(map[int]struct{})
+	for _, raw := range []string{existing, incoming} {
+		var protocols []int
+		if err := json.Unmarshal([]byte(raw), &protocols); err != nil {
+			continue
+		}
+		for _, protocol := range protocols {
+			if _, ok := seen[protocol]; !ok {
+				seen[protocol] = struct{}{}
+				values = append(values, protocol)
+			}
+		}
+	}
+	sort.Ints(values)
+	encoded, err := json.Marshal(values)
+	if err != nil {
+		return "[]"
+	}
+	return string(encoded)
+}
+
+func mergePortJSON(existing, incoming string) string {
+	var all []database.PortStat
+	for _, raw := range []string{existing, incoming} {
+		var ports []database.PortStat
+		if err := json.Unmarshal([]byte(raw), &ports); err == nil {
+			all = append(all, ports...)
+		}
+	}
+	merged := make(map[[2]int]int64, len(all))
+	for _, port := range all {
+		merged[[2]int{port.Proto, port.Port}] += port.Bytes
+	}
+	result := make([]database.PortStat, 0, len(merged))
+	for key, bytes := range merged {
+		result = append(result, database.PortStat{Proto: key[0], Port: key[1], Bytes: bytes})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Bytes != result[j].Bytes {
+			return result[i].Bytes > result[j].Bytes
+		}
+		if result[i].Proto != result[j].Proto {
+			return result[i].Proto < result[j].Proto
+		}
+		return result[i].Port < result[j].Port
+	})
+	if len(result) > 20 {
+		result = result[:20]
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return "[]"
+	}
+	return string(encoded)
 }

--- a/backend/internal/services/rolling_cache_test.go
+++ b/backend/internal/services/rolling_cache_test.go
@@ -62,3 +62,23 @@ func TestRollingCacheMergesProtocolAndPortMetadata(t *testing.T) {
 		t.Fatalf("merged ports = %+v", ports)
 	}
 }
+
+func TestRollingCacheCountsUniquePairsAcrossTrafficTypes(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Minute)
+	cache := NewRollingWindowCache(10 * time.Minute)
+	cache.Update(
+		[]database.NodePairAggregate{{Bucket: now.Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual"}},
+		nil, nil,
+		[]database.TrafficStats{{Bucket: now.Unix(), VirtualBytes: 10, UniquePairs: 1}},
+	)
+	cache.Update(
+		[]database.NodePairAggregate{{Bucket: now.Unix(), SrcNodeID: "c", DstNodeID: "d", TrafficType: "subnet"}},
+		nil, nil,
+		[]database.TrafficStats{{Bucket: now.Unix(), SubnetBytes: 20, UniquePairs: 1}},
+	)
+
+	stats := cache.GetTrafficStats(now, now.Add(time.Minute))
+	if len(stats) != 1 || stats[0].UniquePairs != 2 {
+		t.Fatalf("traffic stats = %+v, want two unique pairs", stats)
+	}
+}

--- a/backend/internal/services/rolling_cache_test.go
+++ b/backend/internal/services/rolling_cache_test.go
@@ -33,6 +33,24 @@ func TestRollingCacheUsesHalfOpenRangesAndCompleteCoverage(t *testing.T) {
 	}
 }
 
+func TestRollingCacheUnalignedRangeMatchesGetterCoverage(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Minute)
+	cache := NewRollingWindowCache(10 * time.Minute)
+	cache.Update(
+		[]database.NodePairAggregate{{Bucket: now.Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual"}},
+		nil, nil, nil,
+	)
+
+	start := now.Add(30 * time.Second)
+	end := now.Add(time.Minute)
+	if got := cache.GetNodePairs(start, end); len(got) != 0 {
+		t.Fatalf("getter returned %d bucket(s), want none before the bucket start", len(got))
+	}
+	if cache.HasNodePairDataFor(start, end) {
+		t.Fatal("unaligned range must not report coverage for an excluded bucket")
+	}
+}
+
 func TestRollingCacheMergesProtocolAndPortMetadata(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Minute)
 	cache := NewRollingWindowCache(10 * time.Minute)
@@ -60,6 +78,39 @@ func TestRollingCacheMergesProtocolAndPortMetadata(t *testing.T) {
 	}
 	if len(ports) != 2 || ports[0].Port != 53 || ports[1].Port != 443 {
 		t.Fatalf("merged ports = %+v", ports)
+	}
+}
+
+func TestRollingCacheMergesDirectionalMetadata(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Minute)
+	cache := NewRollingWindowCache(10 * time.Minute)
+	cache.Update([]database.NodePairAggregate{{
+		Bucket: now.Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+		TxBytes: 100, Protocols: "[6]", ProtocolBytes: `{"6":100}`,
+		TxProtocolBytes: `{"6":100}`, TxPorts: `[{"port":443,"proto":6,"bytes":100}]`, DirectionalPorts: true,
+	}}, nil, nil, nil)
+	cache.Update([]database.NodePairAggregate{{
+		Bucket: now.Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+		RxBytes: 40, Protocols: "[17]", ProtocolBytes: `{"17":40}`,
+		RxProtocolBytes: `{"17":40}`, RxPorts: `[{"port":53,"proto":17,"bytes":40}]`, DirectionalPorts: true,
+	}}, nil, nil, nil)
+
+	pairs := cache.GetNodePairs(now, now.Add(time.Minute))
+	if len(pairs) != 1 || !pairs[0].DirectionalPorts {
+		t.Fatalf("cached pair = %+v", pairs)
+	}
+	if pairs[0].TxProtocolBytes != `{"6":100}` || pairs[0].RxProtocolBytes != `{"17":40}` {
+		t.Fatalf("directional protocol bytes = tx %s rx %s", pairs[0].TxProtocolBytes, pairs[0].RxProtocolBytes)
+	}
+	var txPorts, rxPorts []database.PortStat
+	if err := json.Unmarshal([]byte(pairs[0].TxPorts), &txPorts); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(pairs[0].RxPorts), &rxPorts); err != nil {
+		t.Fatal(err)
+	}
+	if len(txPorts) != 1 || txPorts[0].Port != 443 || len(rxPorts) != 1 || rxPorts[0].Port != 53 {
+		t.Fatalf("directional cached ports = tx %+v rx %+v", txPorts, rxPorts)
 	}
 }
 

--- a/backend/internal/services/rolling_cache_test.go
+++ b/backend/internal/services/rolling_cache_test.go
@@ -133,3 +133,21 @@ func TestRollingCacheCountsUniquePairsAcrossTrafficTypes(t *testing.T) {
 		t.Fatalf("traffic stats = %+v, want two unique pairs", stats)
 	}
 }
+
+func TestRollingCacheCountsDelimiterContainingPairsSeparately(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Minute)
+	cache := NewRollingWindowCache(10 * time.Minute)
+	cache.Update(
+		[]database.NodePairAggregate{
+			{Bucket: now.Unix(), SrcNodeID: "a|b", DstNodeID: "c", TrafficType: "virtual"},
+			{Bucket: now.Unix(), SrcNodeID: "a", DstNodeID: "b|c", TrafficType: "virtual"},
+		},
+		nil, nil,
+		[]database.TrafficStats{{Bucket: now.Unix(), VirtualBytes: 300, TotalFlows: 2, UniquePairs: 1}},
+	)
+
+	stats := cache.GetTrafficStats(now, now.Add(time.Minute))
+	if len(stats) != 1 || stats[0].UniquePairs != 2 {
+		t.Fatalf("traffic stats = %+v, want two delimiter-containing pairs", stats)
+	}
+}

--- a/backend/internal/services/rolling_cache_test.go
+++ b/backend/internal/services/rolling_cache_test.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rajsinghtech/tsflow/backend/internal/database"
+)
+
+func TestRollingCacheUsesHalfOpenRangesAndCompleteCoverage(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Minute)
+	cache := NewRollingWindowCache(10 * time.Minute)
+	cache.Update(
+		[]database.NodePairAggregate{{Bucket: now.Add(-time.Minute).Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual"}},
+		nil, nil, nil,
+	)
+
+	if got := cache.GetNodePairs(now.Add(-time.Minute), now); len(got) != 1 {
+		t.Fatalf("expected one bucket in half-open range, got %d", len(got))
+	}
+	if got := cache.GetNodePairs(now, now.Add(time.Minute)); len(got) != 0 {
+		t.Fatalf("expected end boundary to be excluded, got %d", len(got))
+	}
+	if !cache.HasNodePairDataFor(now.Add(-time.Minute), now) {
+		t.Fatal("expected complete pair coverage")
+	}
+	if cache.HasNodePairDataFor(now.Add(-2*time.Minute), now) {
+		t.Fatal("partial pair coverage should miss")
+	}
+	if cache.HasBandwidthDataFor(now.Add(-time.Minute), now) {
+		t.Fatal("pair data must not satisfy bandwidth coverage")
+	}
+}
+
+func TestRollingCacheMergesProtocolAndPortMetadata(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Minute)
+	cache := NewRollingWindowCache(10 * time.Minute)
+	cache.Update([]database.NodePairAggregate{{
+		Bucket: now.Add(-time.Minute).Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+		TxBytes: 100, Protocols: "[6]", ProtocolBytes: `{"6":100}`,
+		Ports: `[{"port":443,"proto":6,"bytes":100}]`,
+	}}, nil, nil, nil)
+	cache.Update([]database.NodePairAggregate{{
+		Bucket: now.Add(-time.Minute).Unix(), SrcNodeID: "a", DstNodeID: "b", TrafficType: "virtual",
+		TxBytes: 300, Protocols: "[17]", ProtocolBytes: `{"17":300}`,
+		Ports: `[{"port":53,"proto":17,"bytes":300}]`,
+	}}, nil, nil, nil)
+
+	got := cache.GetNodePairs(now.Add(-time.Minute), now)
+	if len(got) != 1 || got[0].TxBytes != 400 {
+		t.Fatalf("unexpected merged pair: %+v", got)
+	}
+	if got[0].Protocols != "[17,6]" {
+		t.Fatalf("protocol order = %s, want [17,6]", got[0].Protocols)
+	}
+	var ports []database.PortStat
+	if err := json.Unmarshal([]byte(got[0].Ports), &ports); err != nil {
+		t.Fatal(err)
+	}
+	if len(ports) != 2 || ports[0].Port != 53 || ports[1].Port != 443 {
+		t.Fatalf("merged ports = %+v", ports)
+	}
+}

--- a/backend/internal/services/tailscale.go
+++ b/backend/internal/services/tailscale.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -711,6 +712,9 @@ func (ts *TailscaleService) GetVIPServices(ctx context.Context) (map[string]VIPS
 
 	body, err := ts.makeRequest(ctx, endpoint)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
 		// VIP services might not be available for all tailnets
 		// Return empty map instead of error for graceful degradation
 		return make(map[string]VIPServiceInfo), nil
@@ -739,6 +743,9 @@ func (ts *TailscaleService) GetStaticRecords(ctx context.Context) (map[string]St
 
 	body, err := ts.makeRequest(ctx, endpoint)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
 		// Static records might not be available for all tailnets
 		// Return empty map instead of error for graceful degradation
 		return make(map[string]StaticRecordInfo), nil

--- a/backend/internal/services/tailscale.go
+++ b/backend/internal/services/tailscale.go
@@ -231,7 +231,7 @@ func (ts *TailscaleService) GetDevicesWithContext(parent context.Context) (*Devi
 	}
 
 	// Fallback to old implementation
-	endpoint := fmt.Sprintf("/tailnet/%s/devices", ts.tailnet)
+	endpoint := fmt.Sprintf("/tailnet/%s/devices", url.PathEscape(ts.tailnet))
 
 	ctx, cancel := context.WithTimeout(parent, 5*time.Minute)
 	defer cancel()
@@ -259,7 +259,7 @@ func (ts *TailscaleService) GetUsersWithContext(parent context.Context) ([]byte,
 	if parent == nil {
 		parent = context.Background()
 	}
-	endpoint := fmt.Sprintf("/tailnet/%s/users", ts.tailnet)
+	endpoint := fmt.Sprintf("/tailnet/%s/users", url.PathEscape(ts.tailnet))
 
 	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	defer cancel()
@@ -276,7 +276,7 @@ func (ts *TailscaleService) GetPolicyWithContext(parent context.Context) ([]byte
 	if parent == nil {
 		parent = context.Background()
 	}
-	endpoint := fmt.Sprintf("/tailnet/%s/acl", ts.tailnet)
+	endpoint := fmt.Sprintf("/tailnet/%s/acl", url.PathEscape(ts.tailnet))
 
 	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	defer cancel()
@@ -341,7 +341,7 @@ func (ts *TailscaleService) getNetworkLogsWithContext(parent context.Context, st
 
 	// Fallback to old implementation
 	endpoint := fmt.Sprintf("/tailnet/%s/logging/network?start=%s&end=%s",
-		ts.tailnet, url.QueryEscape(start), url.QueryEscape(end))
+		url.PathEscape(ts.tailnet), url.QueryEscape(start), url.QueryEscape(end))
 
 	body, err := ts.makeRequest(ctx, endpoint)
 	if err != nil {
@@ -651,7 +651,7 @@ func (ts *TailscaleService) GetDNSNameserversWithContext(parent context.Context)
 	defer cancel()
 
 	// Get nameservers
-	nameserversBody, err := ts.makeRequest(ctx, fmt.Sprintf("/tailnet/%s/dns/nameservers", ts.tailnet))
+	nameserversBody, err := ts.makeRequest(ctx, fmt.Sprintf("/tailnet/%s/dns/nameservers", url.PathEscape(ts.tailnet)))
 	if err != nil {
 		return nil, err
 	}
@@ -662,7 +662,7 @@ func (ts *TailscaleService) GetDNSNameserversWithContext(parent context.Context)
 	}
 
 	// Get preferences
-	prefsBody, err := ts.makeRequest(ctx, fmt.Sprintf("/tailnet/%s/dns/preferences", ts.tailnet))
+	prefsBody, err := ts.makeRequest(ctx, fmt.Sprintf("/tailnet/%s/dns/preferences", url.PathEscape(ts.tailnet)))
 	if err == nil {
 		var prefs map[string]any
 		if json.Unmarshal(prefsBody, &prefs) == nil {

--- a/backend/internal/services/tailscale.go
+++ b/backend/internal/services/tailscale.go
@@ -101,6 +101,10 @@ func (ts *TailscaleService) makeRequest(ctx context.Context, endpoint string) ([
 }
 
 func (ts *TailscaleService) makeRequestWithRetry(ctx context.Context, endpoint string, maxRetries int, initialDelay time.Duration) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var lastErr error
 	delay := initialDelay
 
@@ -245,18 +249,35 @@ func (ts *TailscaleService) GetDevicesWithContext(parent context.Context) (*Devi
 }
 
 func (ts *TailscaleService) GetUsers() ([]byte, error) {
+	return ts.GetUsersWithContext(context.Background())
+}
+
+// GetUsersWithContext allows HTTP handlers to cancel an in-flight request
+// when the client disconnects or the server is shutting down.
+func (ts *TailscaleService) GetUsersWithContext(parent context.Context) ([]byte, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
 	endpoint := fmt.Sprintf("/tailnet/%s/users", ts.tailnet)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	defer cancel()
 
 	return ts.makeRequest(ctx, endpoint)
 }
 
 func (ts *TailscaleService) GetPolicy() ([]byte, error) {
+	return ts.GetPolicyWithContext(context.Background())
+}
+
+// GetPolicyWithContext allows HTTP handlers to cancel an in-flight request.
+func (ts *TailscaleService) GetPolicyWithContext(parent context.Context) ([]byte, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
 	endpoint := fmt.Sprintf("/tailnet/%s/acl", ts.tailnet)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	defer cancel()
 
 	return ts.makeRequest(ctx, endpoint)
@@ -411,6 +432,10 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallel(start, end string, chu
 
 // GetNetworkLogsChunkedParallelWithContext retrieves network logs in parallel chunks with context support
 func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context.Context, start, end string, chunkSize time.Duration, maxConcurrency int) ([]any, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	startTime, err := time.Parse(time.RFC3339, start)
 	if err != nil {
 		return nil, fmt.Errorf("invalid start time: %w", err)
@@ -545,6 +570,9 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 			results[res.index] = res.logs
 		}
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	// Filter out nil results and maintain order
 	var allLogs []any
@@ -571,8 +599,14 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 
 // GetNetworkMap retrieves the network map (simplified version)
 func (ts *TailscaleService) GetNetworkMap() (map[string]any, error) {
+	return ts.GetNetworkMapWithContext(context.Background())
+}
+
+// GetNetworkMapWithContext retrieves the network map using the caller's
+// context for cancellation.
+func (ts *TailscaleService) GetNetworkMapWithContext(ctx context.Context) (map[string]any, error) {
 	// Get devices as the basis for network map
-	devices, err := ts.GetDevices()
+	devices, err := ts.GetDevicesWithContext(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -603,7 +637,16 @@ func (ts *TailscaleService) GetDeviceFlows(deviceID string) (map[string]any, err
 
 // GetDNSNameservers retrieves DNS config for the tailnet
 func (ts *TailscaleService) GetDNSNameservers() (map[string]any, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	return ts.GetDNSNameserversWithContext(context.Background())
+}
+
+// GetDNSNameserversWithContext allows HTTP handlers to cancel both DNS API
+// requests when the client disconnects or the server is shutting down.
+func (ts *TailscaleService) GetDNSNameserversWithContext(parent context.Context) (map[string]any, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	defer cancel()
 
 	// Get nameservers
@@ -627,6 +670,8 @@ func (ts *TailscaleService) GetDNSNameservers() (map[string]any, error) {
 				result["domains"] = domains
 			}
 		}
+	} else if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 
 	// Default values

--- a/backend/internal/services/tailscale.go
+++ b/backend/internal/services/tailscale.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,25 +27,25 @@ type TailscaleService struct {
 }
 
 type Device struct {
-	ID                     string   `json:"id"`
-	Name                   string   `json:"name"`
-	Hostname               string   `json:"hostname"`
-	User                   string   `json:"user"`
-	OS                     string   `json:"os"`
-	Addresses              []string `json:"addresses"`
-	Online                 bool     `json:"online"`
-	LastSeen               string   `json:"lastSeen"`
-	Authorized             bool     `json:"authorized"`
-	KeyExpiryDisabled      bool     `json:"keyExpiryDisabled"`
-	Created                string   `json:"created"`
-	MachineKey             string   `json:"machineKey"`
-	NodeKey                string   `json:"nodeKey"`
+	ID                        string   `json:"id"`
+	Name                      string   `json:"name"`
+	Hostname                  string   `json:"hostname"`
+	User                      string   `json:"user"`
+	OS                        string   `json:"os"`
+	Addresses                 []string `json:"addresses"`
+	Online                    bool     `json:"online"`
+	LastSeen                  string   `json:"lastSeen"`
+	Authorized                bool     `json:"authorized"`
+	KeyExpiryDisabled         bool     `json:"keyExpiryDisabled"`
+	Created                   string   `json:"created"`
+	MachineKey                string   `json:"machineKey"`
+	NodeKey                   string   `json:"nodeKey"`
 	ClientVersion             string   `json:"clientVersion"`
 	UpdateAvailable           bool     `json:"updateAvailable"`
 	BlocksIncomingConnections bool     `json:"blocksIncomingConnections"`
 	EnabledRoutes             []string `json:"enabledRoutes"`
-	AdvertisedRoutes       []string `json:"advertisedRoutes"`
-	Tags                   []string `json:"tags"`
+	AdvertisedRoutes          []string `json:"advertisedRoutes"`
+	Tags                      []string `json:"tags"`
 }
 
 type DevicesResponse struct {
@@ -52,9 +53,11 @@ type DevicesResponse struct {
 }
 
 func NewTailscaleService(cfg *config.Config) *TailscaleService {
+	baseURL := strings.TrimRight(cfg.TailscaleAPIURL, "/")
+	parsedBaseURL, _ := url.Parse(baseURL)
 	ts := &TailscaleService{
 		tailnet: cfg.TailscaleTailnet,
-		baseURL: cfg.TailscaleAPIURL,
+		baseURL: baseURL,
 	}
 
 	if cfg.TailscaleOAuthClientID != "" && cfg.TailscaleOAuthClientSecret != "" {
@@ -63,11 +66,13 @@ func NewTailscaleService(cfg *config.Config) *TailscaleService {
 			ClientID:     cfg.TailscaleOAuthClientID,
 			ClientSecret: cfg.TailscaleOAuthClientSecret,
 			Scopes:       cfg.TailscaleOAuthScopes,
+			BaseURL:      baseURL,
 		}
-		
+
 		ts.tsClient = &tailscale.Client{
-			HTTP:     oauthConfig.HTTPClient(),
-			Tailnet:  cfg.TailscaleTailnet,
+			BaseURL: parsedBaseURL,
+			HTTP:    oauthConfig.HTTPClient(),
+			Tailnet: cfg.TailscaleTailnet,
 		}
 		ts.client = oauthConfig.HTTPClient()
 		ts.useOAuth = true
@@ -77,6 +82,7 @@ func NewTailscaleService(cfg *config.Config) *TailscaleService {
 			Timeout: 30 * time.Minute, // Much longer timeout for large requests
 		}
 		ts.tsClient = &tailscale.Client{
+			BaseURL: parsedBaseURL,
 			APIKey:  cfg.TailscaleAPIKey,
 			Tailnet: cfg.TailscaleTailnet,
 		}
@@ -172,48 +178,57 @@ func (ts *TailscaleService) isRetryableError(err error) bool {
 }
 
 func (ts *TailscaleService) GetDevices() (*DevicesResponse, error) {
+	return ts.GetDevicesWithContext(context.Background())
+}
+
+// GetDevicesWithContext allows background pollers and HTTP handlers to cancel
+// an in-flight device refresh during shutdown or request cancellation.
+func (ts *TailscaleService) GetDevicesWithContext(parent context.Context) (*DevicesResponse, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
 	if ts.tsClient != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(parent, 5*time.Minute)
 		defer cancel()
-		
+
 		devices, err := ts.tsClient.Devices().List(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get devices from tailscale client: %w", err)
 		}
-		
+
 		// Convert tailscale client devices to our format
 		var ourDevices []Device
 		for _, device := range devices {
 			ourDevices = append(ourDevices, Device{
-				ID:                     device.ID,
-				Name:                   device.Name,
-				Hostname:               device.Hostname,
-				User:                   device.User,
-				OS:                     device.OS,
-				Addresses:              device.Addresses,
-				Online:                 !device.LastSeen.IsZero() && time.Since(device.LastSeen.Time) < 2*time.Minute,
-				LastSeen:               device.LastSeen.Time.Format(time.RFC3339),
-				Authorized:             device.Authorized,
-				KeyExpiryDisabled:      device.KeyExpiryDisabled,
-				Created:                device.Created.Time.Format(time.RFC3339),
-				MachineKey:             device.MachineKey,
-				NodeKey:                device.NodeKey,
-				ClientVersion:          device.ClientVersion,
-				UpdateAvailable:        device.UpdateAvailable,
+				ID:                        device.ID,
+				Name:                      device.Name,
+				Hostname:                  device.Hostname,
+				User:                      device.User,
+				OS:                        device.OS,
+				Addresses:                 device.Addresses,
+				Online:                    !device.LastSeen.IsZero() && time.Since(device.LastSeen.Time) < 2*time.Minute,
+				LastSeen:                  device.LastSeen.Time.Format(time.RFC3339),
+				Authorized:                device.Authorized,
+				KeyExpiryDisabled:         device.KeyExpiryDisabled,
+				Created:                   device.Created.Time.Format(time.RFC3339),
+				MachineKey:                device.MachineKey,
+				NodeKey:                   device.NodeKey,
+				ClientVersion:             device.ClientVersion,
+				UpdateAvailable:           device.UpdateAvailable,
 				BlocksIncomingConnections: device.BlocksIncomingConnections,
-				EnabledRoutes:          device.EnabledRoutes,
-				AdvertisedRoutes:       device.AdvertisedRoutes,
-				Tags:                   device.Tags,
+				EnabledRoutes:             device.EnabledRoutes,
+				AdvertisedRoutes:          device.AdvertisedRoutes,
+				Tags:                      device.Tags,
 			})
 		}
-		
+
 		return &DevicesResponse{Devices: ourDevices}, nil
 	}
-	
+
 	// Fallback to old implementation
 	endpoint := fmt.Sprintf("/tailnet/%s/devices", ts.tailnet)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(parent, 5*time.Minute)
 	defer cancel()
 
 	body, err := ts.makeRequest(ctx, endpoint)
@@ -248,29 +263,43 @@ func (ts *TailscaleService) GetPolicy() ([]byte, error) {
 }
 
 func (ts *TailscaleService) GetNetworkLogs(start, end string) (any, error) {
-	// Parse time range to determine if we need chunking
+	return ts.getNetworkLogsWithContext(context.Background(), start, end)
+}
+
+// GetNetworkLogsWithContext is the request-cancellable variant used by HTTP
+// handlers. The legacy GetNetworkLogs method remains available to the poller.
+func (ts *TailscaleService) GetNetworkLogsWithContext(ctx context.Context, start, end string) (any, error) {
+	return ts.getNetworkLogsWithContext(ctx, start, end)
+}
+
+func (ts *TailscaleService) getNetworkLogsWithContext(parent context.Context, start, end string) (any, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+
 	startTime, err := time.Parse(time.RFC3339, start)
 	if err != nil {
 		return nil, fmt.Errorf("invalid start time: %w", err)
 	}
-	
+
 	endTime, err := time.Parse(time.RFC3339, end)
 	if err != nil {
 		return nil, fmt.Errorf("invalid end time: %w", err)
 	}
+	if !endTime.After(startTime) {
+		return nil, fmt.Errorf("end time must be after start time")
+	}
 
-	// For smaller ranges, use the original approach
+	timeoutDuration := 10 * time.Minute
+	if endTime.Sub(startTime) > 7*24*time.Hour {
+		timeoutDuration = 30 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(parent, timeoutDuration)
+	defer cancel()
+
 	if ts.tsClient != nil {
-		// Use much longer timeout for larger time ranges
-		timeoutDuration := 10 * time.Minute
-		if endTime.Sub(startTime) > 7*24*time.Hour {
-			timeoutDuration = 30 * time.Minute // Much longer timeout for 30+ day queries
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
-		defer cancel()
-		
 		var logs []tailscale.NetworkFlowLog
-		
+
 		err = ts.tsClient.Logging().GetNetworkFlowLogs(ctx, tailscale.NetworkFlowLogsRequest{
 			Start: startTime,
 			End:   endTime,
@@ -278,7 +307,7 @@ func (ts *TailscaleService) GetNetworkLogs(start, end string) (any, error) {
 			logs = append(logs, log)
 			return nil
 		})
-		
+
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch network logs from tailscale client: %w", err)
 		}
@@ -287,18 +316,10 @@ func (ts *TailscaleService) GetNetworkLogs(start, end string) (any, error) {
 			"logs": logs,
 		}, nil
 	}
-	
+
 	// Fallback to old implementation
 	endpoint := fmt.Sprintf("/tailnet/%s/logging/network?start=%s&end=%s",
 		ts.tailnet, url.QueryEscape(start), url.QueryEscape(end))
-
-	// Use much longer timeout for larger time ranges
-	timeoutDuration := 10 * time.Minute
-	if endTime.Sub(startTime) > 7*24*time.Hour {
-		timeoutDuration = 30 * time.Minute // Much longer timeout for 30+ day queries
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
-	defer cancel()
 
 	body, err := ts.makeRequest(ctx, endpoint)
 	if err != nil {
@@ -334,6 +355,12 @@ func (ts *TailscaleService) GetNetworkLogsChunked(start, end string, chunkSize t
 	if err != nil {
 		return nil, fmt.Errorf("invalid end time: %w", err)
 	}
+	if !endTime.After(startTime) {
+		return nil, fmt.Errorf("end time must be after start time")
+	}
+	if chunkSize <= 0 {
+		return nil, fmt.Errorf("chunk size must be positive")
+	}
 
 	// If the time range is small enough, use the regular method
 	if endTime.Sub(startTime) <= chunkSize {
@@ -355,15 +382,15 @@ func (ts *TailscaleService) GetNetworkLogsChunked(start, end string, chunkSize t
 		}
 
 		// Fetch logs for this chunk
-		logs, err := ts.GetNetworkLogs(
+		logs, err := ts.getNetworkLogsWithContext(context.Background(),
 			currentStart.Format(time.RFC3339),
 			currentEnd.Format(time.RFC3339),
 		)
 		if err != nil {
 			// Log the error but continue with other chunks
-			log.Printf("Error fetching logs for chunk %s to %s: %v", 
-				currentStart.Format(time.RFC3339), 
-				currentEnd.Format(time.RFC3339), 
+			log.Printf("Error fetching logs for chunk %s to %s: %v",
+				currentStart.Format(time.RFC3339),
+				currentEnd.Format(time.RFC3339),
 				err)
 		} else if logs != nil {
 			allLogs = append(allLogs, logs)
@@ -393,6 +420,15 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 	if err != nil {
 		return nil, fmt.Errorf("invalid end time: %w", err)
 	}
+	if !endTime.After(startTime) {
+		return nil, fmt.Errorf("end time must be after start time")
+	}
+	if chunkSize <= 0 {
+		return nil, fmt.Errorf("chunk size must be positive")
+	}
+	if maxConcurrency <= 0 {
+		return nil, fmt.Errorf("max concurrency must be positive")
+	}
 
 	// Calculate chunks
 	var chunks []struct{ start, end time.Time }
@@ -409,7 +445,7 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 
 	// If only one chunk, use regular method
 	if len(chunks) <= 1 {
-		result, err := ts.GetNetworkLogs(start, end)
+		result, err := ts.getNetworkLogsWithContext(ctx, start, end)
 		if err != nil {
 			return nil, err
 		}
@@ -433,7 +469,7 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 		wg.Add(1)
 		go func(index int, chunkStart, chunkEnd time.Time) {
 			defer wg.Done()
-			
+
 			// Recover from panics
 			defer func() {
 				if r := recover(); r != nil {
@@ -444,7 +480,7 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 					}
 				}
 			}()
-			
+
 			// Check context before proceeding
 			select {
 			case <-ctx.Done():
@@ -456,7 +492,7 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 				return
 			default:
 			}
-			
+
 			// Acquire semaphore
 			select {
 			case semaphore <- struct{}{}:
@@ -470,11 +506,11 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 				return
 			}
 
-			logs, err := ts.GetNetworkLogs(
+			logs, err := ts.getNetworkLogsWithContext(ctx,
 				chunkStart.Format(time.RFC3339),
 				chunkEnd.Format(time.RFC3339),
 			)
-			
+
 			resultsChan <- result{
 				index: index,
 				logs:  logs,
@@ -499,7 +535,7 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 			log.Printf("Warning: invalid result index %d, skipping", res.index)
 			continue
 		}
-		
+
 		if res.err != nil {
 			log.Printf("Error fetching chunk %d: %v", res.index, res.err)
 			hasError = true
@@ -627,49 +663,49 @@ type StaticRecordInfo struct {
 // GetVIPServices fetches all VIP services (virtual IP services) for the tailnet
 func (ts *TailscaleService) GetVIPServices(ctx context.Context) (map[string]VIPServiceInfo, error) {
 	endpoint := fmt.Sprintf("/tailnet/%s/services", url.PathEscape(ts.tailnet))
-	
+
 	body, err := ts.makeRequest(ctx, endpoint)
 	if err != nil {
 		// VIP services might not be available for all tailnets
 		// Return empty map instead of error for graceful degradation
 		return make(map[string]VIPServiceInfo), nil
 	}
-	
+
 	var response struct {
 		VIPServices []VIPServiceInfo `json:"vipServices"`
 	}
-	
+
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse VIP services: %w", err)
 	}
-	
+
 	// Convert to map keyed by service name for easy lookup
 	services := make(map[string]VIPServiceInfo)
 	for _, svc := range response.VIPServices {
 		services[svc.Name] = svc
 	}
-	
+
 	return services, nil
 }
 
 // GetStaticRecords fetches all static DNS records for the tailnet
 func (ts *TailscaleService) GetStaticRecords(ctx context.Context) (map[string]StaticRecordInfo, error) {
 	endpoint := fmt.Sprintf("/tailnet/%s/static-records", url.PathEscape(ts.tailnet))
-	
+
 	body, err := ts.makeRequest(ctx, endpoint)
 	if err != nil {
 		// Static records might not be available for all tailnets
 		// Return empty map instead of error for graceful degradation
 		return make(map[string]StaticRecordInfo), nil
 	}
-	
+
 	var response struct {
 		Records map[string]StaticRecordInfo `json:"records"`
 	}
-	
+
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse static records: %w", err)
 	}
-	
+
 	return response.Records, nil
 }

--- a/backend/internal/services/tailscale.go
+++ b/backend/internal/services/tailscale.go
@@ -27,6 +27,14 @@ type TailscaleService struct {
 	tsClient *tailscale.Client
 }
 
+// HasCredentials reports whether this service can make authenticated
+// requests to the Tailscale API. Object-store-only deployments intentionally
+// construct the service so handlers can share the same dependency, but they
+// do not need (or have) API credentials.
+func (ts *TailscaleService) HasCredentials() bool {
+	return ts != nil && (ts.apiKey != "" || ts.tsClient != nil)
+}
+
 type Device struct {
 	ID                        string   `json:"id"`
 	Name                      string   `json:"name"`

--- a/backend/internal/services/tailscale.go
+++ b/backend/internal/services/tailscale.go
@@ -409,11 +409,8 @@ func (ts *TailscaleService) GetNetworkLogsChunked(start, end string, chunkSize t
 			currentEnd.Format(time.RFC3339),
 		)
 		if err != nil {
-			// Log the error but continue with other chunks
-			log.Printf("Error fetching logs for chunk %s to %s: %v",
-				currentStart.Format(time.RFC3339),
-				currentEnd.Format(time.RFC3339),
-				err)
+			return nil, fmt.Errorf("failed to fetch chunk (%s to %s): %w",
+				currentStart.Format(time.RFC3339), currentEnd.Format(time.RFC3339), err)
 		} else if logs != nil {
 			allLogs = append(allLogs, logs)
 		}
@@ -553,6 +550,7 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 
 	// Collect results
 	results := make([]any, len(chunks))
+	chunkErrors := make([]error, len(chunks))
 	var hasError bool
 
 	for res := range resultsChan {
@@ -565,7 +563,9 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 		if res.err != nil {
 			log.Printf("Error fetching chunk %d: %v", res.index, res.err)
 			hasError = true
-			// Store nil for failed chunks
+			chunkErrors[res.index] = res.err
+			// Store nil for failed chunks so the result can still be drained
+			// before returning the first indexed error below.
 			results[res.index] = nil
 		} else {
 			results[res.index] = res.logs
@@ -586,13 +586,13 @@ func (ts *TailscaleService) GetNetworkLogsChunkedParallelWithContext(ctx context
 		}
 	}
 
-	if hasError && len(allLogs) == 0 {
-		return nil, fmt.Errorf("failed to fetch any logs from parallel requests")
-	}
-
-	// Warn about partial failures - data may be incomplete
-	if failedChunks > 0 {
-		log.Printf("Warning: %d/%d chunks failed during parallel fetch - results may be incomplete", failedChunks, len(chunks))
+	if hasError {
+		for index, chunkErr := range chunkErrors {
+			if chunkErr != nil {
+				return nil, fmt.Errorf("failed to fetch chunk %d/%d: %w", index+1, len(chunks), chunkErr)
+			}
+		}
+		return nil, fmt.Errorf("failed to fetch %d/%d chunks", failedChunks, len(chunks))
 	}
 
 	return allLogs, nil

--- a/backend/internal/services/tailscale_test.go
+++ b/backend/internal/services/tailscale_test.go
@@ -1,0 +1,59 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rajsinghtech/tsflow/backend/internal/config"
+)
+
+func TestChunkedNetworkLogValidation(t *testing.T) {
+	service := NewTailscaleService(&config.Config{TailscaleAPIURL: "https://api.tailscale.com"})
+	start := "2026-01-01T00:00:00Z"
+	end := "2026-01-01T01:00:00Z"
+	if _, err := service.GetNetworkLogsChunked(start, start, time.Hour); err == nil {
+		t.Fatal("expected equal range to fail")
+	}
+	if _, err := service.GetNetworkLogsChunked(start, end, 0); err == nil {
+		t.Fatal("expected zero chunk size to fail")
+	}
+	if _, err := service.GetNetworkLogsChunkedParallelWithContext(context.Background(), start, end, time.Hour, 0); err == nil {
+		t.Fatal("expected zero concurrency to fail")
+	}
+	if _, err := service.GetNetworkLogsWithContext(context.Background(), end, start); err == nil {
+		t.Fatal("expected reversed range to fail")
+	}
+}
+
+func TestTailscaleServiceUsesConfiguredAPIURL(t *testing.T) {
+	var requestPath, authorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		authorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"users":[]}`))
+	}))
+	defer server.Close()
+
+	service := NewTailscaleService(&config.Config{
+		TailscaleAPIURL:  server.URL,
+		TailscaleAPIKey:  "test-key",
+		TailscaleTailnet: "example.com",
+	})
+	if _, err := service.GetUsers(); err != nil {
+		t.Fatal(err)
+	}
+	if requestPath != "/api/v2/tailnet/example.com/users" {
+		t.Fatalf("request path=%q", requestPath)
+	}
+	if authorization != "Bearer test-key" {
+		t.Fatalf("authorization=%q", authorization)
+	}
+	if !strings.HasPrefix(service.baseURL, server.URL) {
+		t.Fatalf("base URL=%q", service.baseURL)
+	}
+}

--- a/backend/internal/services/tailscale_test.go
+++ b/backend/internal/services/tailscale_test.go
@@ -135,3 +135,32 @@ func TestTailscaleServiceNilChunkContextIsSafe(t *testing.T) {
 		t.Fatalf("nil context request failed: %v", err)
 	}
 }
+
+func TestTailscaleServiceParallelChunksRejectPartialResults(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	failingStart := start.Add(time.Hour).Format(time.RFC3339)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("start") == failingStart {
+			http.Error(w, "bad chunk", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"logs":[]}`))
+	}))
+	defer server.Close()
+
+	service := NewTailscaleService(&config.Config{
+		TailscaleAPIURL:  server.URL,
+		TailscaleTailnet: "example.com",
+	})
+	_, err := service.GetNetworkLogsChunkedParallelWithContext(
+		context.Background(),
+		start.Format(time.RFC3339),
+		start.Add(2*time.Hour).Format(time.RFC3339),
+		time.Hour,
+		2,
+	)
+	if err == nil || !strings.Contains(err.Error(), "failed to fetch chunk 2/2") {
+		t.Fatalf("parallel chunk error = %v, want second chunk failure", err)
+	}
+}

--- a/backend/internal/services/tailscale_test.go
+++ b/backend/internal/services/tailscale_test.go
@@ -58,6 +58,28 @@ func TestTailscaleServiceUsesConfiguredAPIURL(t *testing.T) {
 	}
 }
 
+func TestTailscaleServiceEscapesTailnetPathSegments(t *testing.T) {
+	var requestPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"users":[]}`))
+	}))
+	defer server.Close()
+
+	service := NewTailscaleService(&config.Config{
+		TailscaleAPIURL:  server.URL,
+		TailscaleAPIKey:  "test-key",
+		TailscaleTailnet: "team/example",
+	})
+	if _, err := service.GetUsers(); err != nil {
+		t.Fatal(err)
+	}
+	if requestPath != "/api/v2/tailnet/team%2Fexample/users" {
+		t.Fatalf("request path = %q, want escaped tailnet segment", requestPath)
+	}
+}
+
 func TestTailscaleServiceRequestsHonorCallerContext(t *testing.T) {
 	started := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/services/tailscale_test.go
+++ b/backend/internal/services/tailscale_test.go
@@ -57,3 +57,59 @@ func TestTailscaleServiceUsesConfiguredAPIURL(t *testing.T) {
 		t.Fatalf("base URL=%q", service.baseURL)
 	}
 }
+
+func TestTailscaleServiceRequestsHonorCallerContext(t *testing.T) {
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	service := NewTailscaleService(&config.Config{
+		TailscaleAPIURL:  server.URL,
+		TailscaleAPIKey:  "test-key",
+		TailscaleTailnet: "example.com",
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := service.GetUsersWithContext(ctx)
+		result <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("request did not reach test server")
+	}
+	cancel()
+
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "context canceled") {
+			t.Fatalf("request error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request did not stop after context cancellation")
+	}
+}
+
+func TestTailscaleServiceNilChunkContextIsSafe(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"logs":[]}`))
+	}))
+	defer server.Close()
+
+	service := NewTailscaleService(&config.Config{
+		TailscaleAPIURL:  server.URL,
+		TailscaleAPIKey:  "test-key",
+		TailscaleTailnet: "example.com",
+	})
+	start := "2026-01-01T00:00:00Z"
+	end := "2026-01-01T00:30:00Z"
+	if _, err := service.GetNetworkLogsChunkedParallelWithContext(nil, start, end, time.Hour, 1); err != nil {
+		t.Fatalf("nil context request failed: %v", err)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -99,21 +99,11 @@ func main() {
 	// Create and start background poller
 	pollerConfig := services.DefaultPollerConfig()
 
-	// Allow configuration via environment variables
-	if interval := os.Getenv("TSFLOW_POLL_INTERVAL"); interval != "" {
-		if d, err := time.ParseDuration(interval); err == nil {
-			pollerConfig.PollInterval = d
-		}
-	}
-	if backfill := os.Getenv("TSFLOW_INITIAL_BACKFILL"); backfill != "" {
-		if d, err := time.ParseDuration(backfill); err == nil {
-			pollerConfig.InitialBackfill = d
-		}
-	}
-	if retention := os.Getenv("TSFLOW_RETENTION"); retention != "" {
-		if d, err := time.ParseDuration(retention); err == nil {
-			pollerConfig.Retention = d
-		}
+	// Configuration values have already been syntax-checked by Config.Validate.
+	pollerConfig.PollInterval, _ = time.ParseDuration(cfg.PollInterval)
+	pollerConfig.InitialBackfill, _ = time.ParseDuration(cfg.InitialBackfill)
+	if cfg.Retention != "" {
+		pollerConfig.Retention, _ = time.ParseDuration(cfg.Retention)
 	}
 	pollerConfig.FlowBackend = cfg.FlowBackend
 	if pollerConfig.FlowBackend == "" {
@@ -122,13 +112,10 @@ func main() {
 			pollerConfig.FlowBackend = "s3"
 		}
 	}
-	if pollerConfig.FlowBackend == "s3" && os.Getenv("TSFLOW_RETENTION") == "" {
+	if pollerConfig.FlowBackend == "s3" && cfg.Retention == "" {
 		pollerConfig.Retention = 0
 	}
-	lookback, err := time.ParseDuration(cfg.FlowObjectStoreLookback)
-	if err != nil {
-		lookback = 15 * time.Minute
-	}
+	lookback, _ := time.ParseDuration(cfg.FlowObjectStoreLookback)
 	pollerConfig.ObjectStore = services.ObjectStoreConfig{
 		Bucket:       cfg.FlowObjectStoreBucket,
 		Prefix:       cfg.FlowObjectStorePrefix,

--- a/backend/main.go
+++ b/backend/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -49,6 +50,13 @@ var (
 )
 
 func main() {
+	if len(os.Args) > 1 && (os.Args[1] == "--help" || os.Args[1] == "-h") {
+		fmt.Println("TSFlow - Tailscale network flow visualizer")
+		fmt.Println("Usage: tsflow [--help]")
+		fmt.Println("Configuration is supplied through environment variables; see the README for details.")
+		return
+	}
+
 	// Configure logging to stdout for container visibility
 	log.SetOutput(os.Stdout)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
@@ -134,6 +142,8 @@ func main() {
 	}
 
 	poller := services.NewPoller(tailscaleService, store, pollerConfig)
+	pollerCtx, pollerCancel := context.WithCancel(context.Background())
+	defer pollerCancel()
 	if pollerConfig.FlowBackend == "s3" {
 		objectSource, err := services.NewObjectStoreSource(ctx, pollerConfig.ObjectStore)
 		if err != nil {
@@ -143,7 +153,7 @@ func main() {
 	}
 
 	// Start poller in background
-	if err := poller.Start(ctx); err != nil {
+	if err := poller.Start(pollerCtx); err != nil {
 		log.Printf("Warning: Failed to start poller: %v", err)
 	}
 
@@ -170,16 +180,15 @@ func main() {
 	router.Use(gzip.Gzip(gzip.DefaultCompression))
 
 	corsConfig := cors.DefaultConfig()
-	// Configure CORS based on allowed origins
-	// In development (no ALLOWED_CORS_ORIGINS set), allow all origins
-	// In production, restrict to specified origins
+	// Configure CORS based on allowed origins. Production deployments must
+	// explicitly opt into cross-origin origins.
 	if len(cfg.AllowedCORSOrigins) > 0 {
 		corsConfig.AllowOrigins = cfg.AllowedCORSOrigins
+	} else if strings.EqualFold(cfg.Environment, "production") {
+		corsConfig.AllowOriginFunc = func(string) bool { return false }
 	} else {
-		// Note: AllowAllOrigins=true with AllowCredentials=true is invalid per CORS spec
-		// Browsers reject this combination. Use AllowOriginFunc for dynamic origin handling.
 		corsConfig.AllowOriginFunc = func(origin string) bool {
-			return true // Allow all origins dynamically (compatible with credentials)
+			return true
 		}
 	}
 	corsConfig.AllowCredentials = true
@@ -329,17 +338,24 @@ func main() {
 		httpSrv.Shutdown(shutdownCtx)
 		tsnetSrv.Close()
 	} else {
+		httpSrv := &http.Server{Addr: "0.0.0.0:" + port, Handler: router}
 		go func() {
-			if err := router.Run("0.0.0.0:" + port); err != nil {
-				log.Fatalf("FATAL Failed to start server: %v", err)
+			if err := httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Printf("FATAL Failed to start server: %v", err)
 			}
 		}()
 
 		<-quit
 		log.Println("Shutting down server...")
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("Error shutting down HTTP server: %v", err)
+		}
+		shutdownCancel()
 	}
 
 	// Stop the poller gracefully
+	pollerCancel()
 	poller.Stop()
 
 	// Close database connection

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,8 @@
         "svelte-check": "^4.0.0",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.0.0",
-        "vite": "^7.0.0"
+        "vite": "^7.0.0",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -1452,6 +1453,17 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1508,6 +1520,13 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1519,6 +1538,119 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@xyflow/svelte": {
       "version": "1.6.3",
@@ -1571,6 +1703,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1578,6 +1720,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -1619,6 +1771,13 @@
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.6.0",
@@ -1787,6 +1946,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
@@ -1850,6 +2016,26 @@
         "@typescript-eslint/types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2262,6 +2448,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2387,6 +2580,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -2411,6 +2611,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -2491,6 +2705,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2506,6 +2737,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -2627,11 +2868,118 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "test": "vitest run --config vitest.config.ts"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.6",
@@ -18,7 +19,8 @@
     "svelte-check": "^4.0.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.0.0",
-    "vite": "^7.0.0"
+    "vite": "^7.0.0",
+    "vitest": "^4.1.10"
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.2",

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -32,6 +32,7 @@
 
 	/* Traffic type colors */
 	--color-traffic-virtual: #3b82f6;
+	--color-traffic-exit: #a855f7;
 	--color-traffic-subnet: #10b981;
 	--color-traffic-physical: #f59e0b;
 
@@ -68,6 +69,7 @@
 
 	/* Traffic type colors - slightly darker for light mode */
 	--color-traffic-virtual: #2563eb;
+	--color-traffic-exit: #9333ea;
 	--color-traffic-subnet: #059669;
 	--color-traffic-physical: #d97706;
 

--- a/frontend/src/lib/components/layout/Header.svelte
+++ b/frontend/src/lib/components/layout/Header.svelte
@@ -90,7 +90,9 @@
 		if (hasNetworkData) return $networkStats.totalBytes;
 		if (!$statsSummary) return 0;
 		const protoTotal = $statsSummary.tcpBytes + $statsSummary.udpBytes + $statsSummary.otherProtoBytes;
-		return protoTotal > 0 ? protoTotal : $statsSummary.virtualBytes + $statsSummary.subnetBytes;
+		return protoTotal > 0
+			? protoTotal
+			: $statsSummary.virtualBytes + $statsSummary.exitBytes + $statsSummary.subnetBytes + $statsSummary.physicalBytes;
 	});
 
 	const avgTrafficPerNode = $derived.by(() => {

--- a/frontend/src/lib/components/logs/LogViewer.svelte
+++ b/frontend/src/lib/components/logs/LogViewer.svelte
@@ -131,6 +131,7 @@
 			const selectedNode = $filteredNodes.find((n) => n.id === selectedNodeId);
 			if (selectedNode) {
 				selectedNodeIPs = new Set(selectedNode.ips);
+				selectedNodeIPs.add(selectedNode.id);
 			}
 		}
 
@@ -198,6 +199,7 @@
 			const selectedNode = $filteredNodes.find((n) => n.id === selectedNodeId);
 			if (selectedNode) {
 				selectedNodeIPsSet = new Set(selectedNode.ips);
+				selectedNodeIPsSet.add(selectedNode.id);
 			}
 		}
 

--- a/frontend/src/lib/components/logs/LogViewer.svelte
+++ b/frontend/src/lib/components/logs/LogViewer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { rawLogs, uiStore, filteredNodes, filteredEdges, processedNetwork, filterStore, debouncedFilterStore, devices, services, primaryMatchedNodes } from '$lib/stores';
-	import { formatBytes, formatTime, extractIP, getProtocolName } from '$lib/utils';
+	import { formatBytes, formatTime, extractIP, extractPort, getProtocolName } from '$lib/utils';
 	import { ArrowRight, ArrowUpDown } from 'lucide-svelte';
 	import type { NetworkLog, TrafficType } from '$lib/types';
 
@@ -78,8 +78,8 @@
 	// Helper to resolve IP or device ID to device/service name
 	function resolveIP(address: string): { ip: string; port?: string; deviceName?: string } {
 		const ip = extractIP(address);
-		const portMatch = address.match(/:(\d+)$/);
-		const port = portMatch ? portMatch[1] : undefined;
+		const parsedPort = extractPort(address);
+		const port = parsedPort === null ? undefined : String(parsedPort);
 		let deviceName = ipToDevice.get(ip);
 		if (!deviceName) {
 			deviceName = deviceIdToName.get(ip);

--- a/frontend/src/lib/components/logs/PortDetails.svelte
+++ b/frontend/src/lib/components/logs/PortDetails.svelte
@@ -78,7 +78,9 @@
 					const key = `${port}-${protocol}`;
 					const existing = portMap.get(key);
 					const txAdd = nodeIsSrc ? bytes : 0;
-					const rxAdd = nodeIsDst ? bytes : 0;
+					// If both endpoints belong to the selected node, this is a self-flow;
+					// count it once as TX instead of also attributing it as RX.
+					const rxAdd = nodeIsDst && !nodeIsSrc ? bytes : 0;
 
 					if (existing) {
 						existing.txBytes += txAdd;

--- a/frontend/src/lib/components/logs/PortDetails.svelte
+++ b/frontend/src/lib/components/logs/PortDetails.svelte
@@ -51,6 +51,7 @@
 		if (!selectedNode) return { stats: [], totalCount: 0 };
 
 		const nodeIPs = new Set(selectedNode.ips || []);
+		nodeIPs.add(selectedNode.id);
 		const portMap = new Map<string, PortStat>();
 
 		$rawLogs.forEach((log: NetworkLog) => {
@@ -71,26 +72,37 @@
 				const nodeIsSrc = nodeIPs.has(srcIP);
 				const nodeIsDst = nodeIPs.has(dstIP);
 				if (!nodeIsSrc && !nodeIsDst) return;
-				if (dstPort === 0) return;
 
-				const key = `${dstPort}-${proto}`;
-				const existing = portMap.get(key);
-				const txAdd = nodeIsSrc ? (t.txBytes || 0) : 0;
-				const rxAdd = nodeIsDst ? (t.txBytes || 0) : 0;
+				const addPort = (port: number, protocol: string, bytes: number) => {
+					if (port <= 0) return;
+					const key = `${port}-${protocol}`;
+					const existing = portMap.get(key);
+					const txAdd = nodeIsSrc ? bytes : 0;
+					const rxAdd = nodeIsDst ? bytes : 0;
 
-				if (existing) {
-					existing.txBytes += txAdd;
-					existing.rxBytes += rxAdd;
-					existing.connections += 1;
+					if (existing) {
+						existing.txBytes += txAdd;
+						existing.rxBytes += rxAdd;
+						existing.connections += 1;
+					} else {
+						portMap.set(key, {
+							port,
+							name: getPortName(port),
+							protocol,
+							txBytes: txAdd,
+							rxBytes: rxAdd,
+							connections: 1
+						});
+					}
+				};
+
+				if (t.ports?.length) {
+					for (const stat of t.ports) {
+						addPort(stat.port, getProtocolName(stat.proto), stat.bytes || 0);
+					}
 				} else {
-					portMap.set(key, {
-						port: dstPort,
-						name: getPortName(dstPort),
-						protocol: proto,
-						txBytes: txAdd,
-						rxBytes: rxAdd,
-						connections: 1
-					});
+					if (dstPort === 0) return;
+					addPort(dstPort, proto, t.txBytes || 0);
 				}
 			});
 		});
@@ -111,6 +123,7 @@
 		if (!selectedNode) return { tx: 0, rx: 0, total: 0 };
 
 		const nodeIPs = new Set(selectedNode.ips || []);
+		nodeIPs.add(selectedNode.id);
 		let tx = 0;
 		let rx = 0;
 

--- a/frontend/src/lib/policy-engine/parser.ts
+++ b/frontend/src/lib/policy-engine/parser.ts
@@ -14,18 +14,33 @@ import {
 } from "./types";
 
 const IPV4 = /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
+const IPV6_GROUP = /^[0-9a-fA-F]{1,4}$/;
+
+function isIpv6(value: string): boolean {
+	const raw = value.replace(/^\[|\]$/g, "");
+	if (!raw || raw.includes(".") || raw.split("::").length > 2) return false;
+	const parts = raw.split("::");
+	const left = parts[0] ? parts[0].split(":") : [];
+	const right = parts.length === 2 && parts[1] ? parts[1].split(":") : [];
+	if (![...left, ...right].every((group) => IPV6_GROUP.test(group))) return false;
+	const groupCount = left.length + right.length;
+	return parts.length === 2 ? groupCount < 8 : groupCount === 8;
+}
 
 function isIp(value: string): boolean {
-  return IPV4.test(value) || value.includes(":");
+	return IPV4.test(value) || isIpv6(value);
 }
 
 function isCidr(value: string): boolean {
-  const [ip, mask] = value.split("/");
-  if (!ip || !mask) {
-    return false;
-  }
-  const n = Number(mask);
-  return Number.isInteger(n) && n >= 0 && n <= 128 && isIp(ip);
+	const slash = value.lastIndexOf("/");
+	if (slash <= 0 || slash === value.length - 1 || value.indexOf("/") !== slash) {
+		return false;
+	}
+	const ip = value.slice(0, slash);
+	const mask = value.slice(slash + 1);
+	const n = Number(mask);
+	const maxMask = isIpv6(ip) ? 128 : 32;
+	return /^\d+$/.test(mask) && Number.isInteger(n) && n >= 0 && n <= maxMask && isIp(ip);
 }
 
 function dedupePush(list: string[], value: string): void {
@@ -53,16 +68,51 @@ function normalizeNodeType(raw: string, ctx: NormalizeContext): NodeType {
 }
 
 function parseAclDst(raw: string): { selector: string; ports: string[] | undefined } {
-  const lastColon = raw.lastIndexOf(":");
+	if (raw.startsWith("[") && raw.includes("]:")) {
+		const close = raw.indexOf("]:");
+		const selector = close > 1 ? raw.slice(1, close) : raw;
+		const portSpec = close > 1 ? raw.slice(close + 2) : "";
+		if (close > 1 && isValidPortSpec(portSpec)) {
+			return { selector, ports: [portSpec] };
+		}
+		// Preserve the endpoint selector while retaining an impossible port so
+		// malformed bracketed IPv6 destinations cannot match as unrestricted
+		// traffic.
+		if (close > 1 && isIpv6(selector)) {
+			return { selector, ports: ["__invalid__"] };
+		}
+		if (close > 1) {
+			return { selector, ports: ["__invalid__"] };
+		}
+	}
+	// An unadorned IP/CIDR is a selector, not an IPv6 selector with a port
+	// suffix. Bracket notation is required when an IPv6 port is specified.
+	if (isIp(raw) || isCidr(raw)) {
+		return { selector: raw, ports: undefined };
+	}
+	const lastColon = raw.lastIndexOf(":");
   if (lastColon <= 0 || raw.startsWith("svc:")) {
     return { selector: raw, ports: undefined };
   }
   const left = raw.slice(0, lastColon);
   const right = raw.slice(lastColon + 1);
-  if (!right || !/^[\d,*-]+$/.test(right)) {
-    return { selector: raw, ports: undefined };
-  }
-  return { selector: left, ports: right.split(",") };
+	if (!isValidPortSpecList(right)) {
+		return { selector: raw, ports: undefined };
+	}
+	return { selector: left, ports: right.split(",") };
+}
+
+function isValidPortSpec(value: string): boolean {
+	if (value === "*") return true;
+	const range = value.split("-");
+	if (range.length > 2 || !range.every((part) => /^\d+$/.test(part))) return false;
+	const start = Number(range[0]);
+	const end = range.length === 2 ? Number(range[1]) : start;
+	return start >= 1 && start <= 65535 && end >= start && end <= 65535;
+}
+
+function isValidPortSpecList(value: string): boolean {
+	return value.split(",").length > 0 && value.split(",").every(isValidPortSpec);
 }
 
 class Builder {
@@ -114,7 +164,12 @@ class Builder {
 }
 
 function ensureArray(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+	return Array.isArray(value)
+		? value
+				.filter((item): item is string => typeof item === "string")
+				.map((item) => item.trim())
+				.filter(Boolean)
+		: [];
 }
 
 function addAccessEdges(

--- a/frontend/src/lib/policy-engine/parser.ts
+++ b/frontend/src/lib/policy-engine/parser.ts
@@ -202,8 +202,6 @@ function parseAcls(builder: Builder, policy: TailnetPolicy): void {
   const rules = policy.acls ?? [];
   rules.forEach((rule: AclRule, index) => {
     const src = ensureArray(rule.src);
-    const dstSelectors: string[] = [];
-    const portsAccumulator = new Set<string>();
 
     ensureArray(rule.dst).forEach((raw, dstIndex) => {
       const parsed = parseAclDst(raw);
@@ -215,14 +213,15 @@ function parseAcls(builder: Builder, policy: TailnetPolicy): void {
           ruleRef: { section: "acls", index }
         });
       }
-      dstSelectors.push(parsed.selector);
-      parsed.ports?.forEach((p) => portsAccumulator.add(p));
-    });
 
-    addAccessEdges(builder, "acls", index, src, dstSelectors, {
-      action: rule.action,
-      proto: rule.proto,
-      ports: portsAccumulator.size > 0 ? Array.from(portsAccumulator) : undefined
+      // Port qualifiers belong to the individual destination expression.
+      // Keeping one accumulator for the whole rule would make every emitted
+      // edge accept every port mentioned by any other destination.
+      addAccessEdges(builder, "acls", index, src, [parsed.selector], {
+        action: rule.action,
+        proto: rule.proto,
+        ports: parsed.ports
+      });
     });
   });
 }

--- a/frontend/src/lib/policy-engine/query.ts
+++ b/frontend/src/lib/policy-engine/query.ts
@@ -1,8 +1,6 @@
 import { type AccessEdgeKind, type GraphEdge, type PolicyGraph, type QueryFilters, type QueryResult } from "./types";
 
 const ACCESS_TYPES: AccessEdgeKind[] = ["grant", "acl", "ssh"];
-const RELATION_TYPES = new Set(["member-of", "owns-tag", "contains", "resolves-to"]);
-
 function resolveFocusNodeId(graph: PolicyGraph, selectorOrNodeId: string): string | null {
   if (graph.nodes.some((n) => n.id === selectorOrNodeId)) {
     return selectorOrNodeId;
@@ -23,16 +21,22 @@ function filterAccessEdges(edges: GraphEdge[], filters?: QueryFilters): GraphEdg
   });
 }
 
-// Resolve all selectors that effectively represent this node:
-// the node itself + groups it belongs to + autogroups (via member-of edges)
+// Resolve all selectors that effectively represent this node: the node itself
+// plus every transitive group/autogroup that contains it. Relation edges use
+// source=container and target=member, so walking backwards handles nested
+// groups without looping on malformed cyclic policy input.
 function resolveEffectiveSelectors(graph: PolicyGraph, nodeId: string): Set<string> {
-  const selectors = new Set<string>([nodeId]);
-  for (const edge of graph.edges) {
-    if (edge.type === "member-of" && edge.target === nodeId) {
-      // member-of: source=group, target=member → this node is in source group
-      selectors.add(edge.source);
-    }
-  }
+	const selectors = new Set<string>([nodeId]);
+	const pending = [nodeId];
+	while (pending.length > 0) {
+		const member = pending.pop()!;
+		for (const edge of graph.edges) {
+			if (edge.type === "member-of" && edge.target === member && !selectors.has(edge.source)) {
+				selectors.add(edge.source);
+				pending.push(edge.source);
+			}
+		}
+	}
   return selectors;
 }
 

--- a/frontend/src/lib/services/index.ts
+++ b/frontend/src/lib/services/index.ts
@@ -3,8 +3,6 @@ export {
 	tailscaleService,
 	type DataRange,
 	type PollerStatus,
-	type StoredFlowLog,
-	type StoredFlowLogsResponse,
 	type AggregatedFlow,
 	type AggregatedFlowsResponse,
 	type BandwidthBucket,

--- a/frontend/src/lib/services/tailscale-service.ts
+++ b/frontend/src/lib/services/tailscale-service.ts
@@ -117,8 +117,8 @@ export const tailscaleService = {
 		return api.get<AggregatedFlowsResponse>(url, { signal });
 	},
 
-	async getDataRange(): Promise<DataRange> {
-		return api.get<DataRange>('/flow-logs/range');
+	async getDataRange(signal?: AbortSignal): Promise<DataRange> {
+		return api.get<DataRange>('/flow-logs/range', { signal });
 	},
 
 	async getPollerStatus(): Promise<PollerStatus> {

--- a/frontend/src/lib/services/tailscale-service.ts
+++ b/frontend/src/lib/services/tailscale-service.ts
@@ -16,36 +16,6 @@ export interface DataRange {
 	count: number;
 }
 
-export interface StoredFlowLog {
-	id: number;
-	loggedAt: string;
-	nodeId: string;
-	periodStart: string;
-	periodEnd: string;
-	trafficType: string;
-	protocol: number;
-	srcIp: string;
-	srcPort: number;
-	dstIp: string;
-	dstPort: number;
-	txBytes: number;
-	rxBytes: number;
-	txPkts: number;
-	rxPkts: number;
-	createdAt: string;
-}
-
-export interface StoredFlowLogsResponse {
-	logs: StoredFlowLog[];
-	metadata: {
-		count: number;
-		start: string;
-		end: string;
-		limit: number;
-		source: string;
-	};
-}
-
 export interface AggregatedFlow {
 	// Node pair aggregates (device IDs or IPs for external nodes)
 	srcNodeId: string;
@@ -58,6 +28,7 @@ export interface AggregatedFlow {
 	totalTxPkts: number;
 	totalRxPkts: number;
 	flowCount: number;
+	ports?: { port: number; proto: number; bytes: number }[];
 	// Legacy fields for backwards compatibility
 	nodeId?: string;
 	protocol?: number;
@@ -134,14 +105,6 @@ export const tailscaleService = {
 
 	async getServicesRecords(signal?: AbortSignal): Promise<ServicesResponse> {
 		return api.get<ServicesResponse>('/services-records', { signal });
-	},
-
-	async getStoredFlowLogs(start: Date, end: Date, limit = 50000, signal?: AbortSignal): Promise<StoredFlowLogsResponse> {
-		const startISO = start.toISOString();
-		const endISO = end.toISOString();
-		return api.get<StoredFlowLogsResponse>(
-			`/flow-logs?start=${startISO}&end=${endISO}&limit=${limit}`, { signal }
-		);
 	},
 
 	async getAggregatedFlows(start: Date, end: Date, trafficTypes?: string[], signal?: AbortSignal): Promise<AggregatedFlowsResponse> {

--- a/frontend/src/lib/services/tailscale-service.ts
+++ b/frontend/src/lib/services/tailscale-service.ts
@@ -1,5 +1,5 @@
 import { api } from './api-service';
-import type { Device, NetworkLogsResponse, TrafficStatsBucket, TrafficStatsSummary, TopTalker, TopPair, NodeDetailStats } from '$lib/types';
+import type { Device, NetworkLogsResponse, PortStat, TrafficStatsBucket, TrafficStatsSummary, TopTalker, TopPair, NodeDetailStats } from '$lib/types';
 
 export interface DevicesResponse {
 	devices: Device[];
@@ -28,7 +28,14 @@ export interface AggregatedFlow {
 	totalTxPkts: number;
 	totalRxPkts: number;
 	flowCount: number;
-	ports?: { port: number; proto: number; bytes: number }[];
+	ports?: PortStat[];
+	// Directional aggregate metadata. These fields are omitted by older
+	// backends/legacy rows and must not be inferred from the union ports field.
+	directional?: boolean;
+	txProtocolBytes?: Record<string, number>;
+	rxProtocolBytes?: Record<string, number>;
+	txPorts?: PortStat[];
+	rxPorts?: PortStat[];
 	// Legacy fields for backwards compatibility
 	nodeId?: string;
 	protocol?: number;

--- a/frontend/src/lib/stores/data-source-store.ts
+++ b/frontend/src/lib/stores/data-source-store.ts
@@ -46,6 +46,8 @@ function latestWindow(range: DataRange, windowMs = DEFAULT_WINDOW_MS): { start: 
 function createDataSourceStore() {
 	const { subscribe, set, update } = writable<DataSourceState>(defaultState);
 	let dataRangeRequest: Promise<DataRange | null> | null = null;
+	let dataRangeGeneration = 0;
+	let dataRangeRequestToken = 0;
 	let pollerStatusRequest: Promise<PollerStatus | null> | null = null;
 
 	return {
@@ -77,14 +79,23 @@ function createDataSourceStore() {
 				};
 			}),
 
-		async fetchDataRange() {
-			if (dataRangeRequest) return dataRangeRequest;
+		async fetchDataRange(signal?: AbortSignal) {
+			if (signal?.aborted) return null;
+			// Requests with a caller-owned signal must not share the uncancellable
+			// legacy request or another caller's signal. This keeps a refresh that
+			// was superseded from updating the active refresh's state.
+			if (!signal && dataRangeRequest) return dataRangeRequest;
+			if (signal) dataRangeRequest = null;
+			const requestToken = ++dataRangeRequestToken;
+			const requestGeneration = dataRangeGeneration;
 			update((s) => ({ ...s, isLoading: true, error: null }));
-			dataRangeRequest = (async () => {
+			let request: Promise<DataRange | null> | null = null;
+			request = (async () => {
 				try {
-					const dataRange = await tailscaleService.getDataRange();
+					const dataRange = await tailscaleService.getDataRange(signal);
+					if (signal?.aborted || requestToken !== dataRangeRequestToken || requestGeneration !== dataRangeGeneration) return null;
 					update((s) => {
-						const next = { ...s, dataRange, isLoading: false };
+						const next = { ...s, dataRange };
 						if (s.followLatest && hasValidRange(dataRange)) {
 							const selected = latestWindow(dataRange, s.latestWindowMs);
 							next.selectedStart = selected.start;
@@ -94,14 +105,19 @@ function createDataSourceStore() {
 					});
 					return dataRange;
 				} catch (err) {
+					if (signal?.aborted || requestToken !== dataRangeRequestToken || requestGeneration !== dataRangeGeneration) return null;
 					const error = err instanceof Error ? err.message : 'Failed to fetch data range';
-					update((s) => ({ ...s, error, isLoading: false }));
+					update((s) => ({ ...s, error }));
 					return null;
 				} finally {
-					dataRangeRequest = null;
+					if (requestToken === dataRangeRequestToken && requestGeneration === dataRangeGeneration) {
+						update((s) => ({ ...s, isLoading: false }));
+					}
+					if (!signal && request !== null && dataRangeRequest === request) dataRangeRequest = null;
 				}
 			})();
-			return dataRangeRequest;
+			if (!signal) dataRangeRequest = request;
+			return request;
 		},
 
 		async fetchPollerStatus() {
@@ -125,6 +141,7 @@ function createDataSourceStore() {
 
 		reset: () => {
 			dataRangeRequest = null;
+			dataRangeGeneration++;
 			pollerStatusRequest = null;
 			set(defaultState);
 		}

--- a/frontend/src/lib/stores/network-store.ts
+++ b/frontend/src/lib/stores/network-store.ts
@@ -1,5 +1,5 @@
 import { writable, derived, get } from 'svelte/store';
-import type { Device, NetworkLog, NetworkNode, NetworkLink } from '$lib/types';
+import type { Device, NetworkLog, NetworkNode, NetworkLink, PortStat, TrafficEntry } from '$lib/types';
 import { tailscaleService, type AggregatedFlow } from '$lib/services';
 import { processNetworkLogs } from '$lib/utils/network-processor';
 import { filterStore, debouncedFilterStore } from './filter-store';
@@ -333,6 +333,72 @@ function formatSyntheticDeviceName(id: string, displayName?: string): string {
 	return raw;
 }
 
+function normalizeProtocolBytes(protocolBytes: Record<string, number> | undefined, fallbackProtocol: number, fallbackBytes: number) {
+	const normalized: Record<string, number> = {};
+	for (const [rawProtocol, bytes] of Object.entries(protocolBytes || {})) {
+		const protocol = Number(rawProtocol);
+		if (!Number.isInteger(protocol) || protocol < 0 || !Number.isFinite(bytes)) continue;
+		normalized[String(protocol)] = bytes;
+	}
+	if (Object.keys(normalized).length === 0 && fallbackBytes > 0) {
+		normalized[String(fallbackProtocol || 0)] = fallbackBytes;
+	}
+	return normalized;
+}
+
+function dominantProtocol(protocolBytes: Record<string, number>, fallbackProtocol: number): number {
+	let dominant = fallbackProtocol || 0;
+	let dominantBytes = -1;
+	for (const [rawProtocol, bytes] of Object.entries(protocolBytes)) {
+		const protocol = Number(rawProtocol);
+		if (!Number.isInteger(protocol) || !Number.isFinite(bytes)) continue;
+		if (bytes > dominantBytes || (bytes === dominantBytes && protocol < dominant)) {
+			dominant = protocol;
+			dominantBytes = bytes;
+		}
+	}
+	return dominant;
+}
+
+function mergePortStats(...lists: (PortStat[] | undefined)[]): PortStat[] {
+	const merged = new Map<string, PortStat>();
+	for (const list of lists) {
+		for (const stat of list || []) {
+			if (stat.port <= 0) continue;
+			const key = `${stat.proto}:${stat.port}`;
+			const existing = merged.get(key);
+			if (existing) existing.bytes += stat.bytes || 0;
+			else merged.set(key, { ...stat });
+		}
+	}
+	return Array.from(merged.values());
+}
+
+function makeAggregateTrafficEntry(
+	src: string,
+	dst: string,
+	bytes: number,
+	packets: number,
+	protocolBytes: Record<string, number>,
+	ports: PortStat[],
+	directional: boolean
+): TrafficEntry {
+	const entry: TrafficEntry = {
+		proto: dominantProtocol(protocolBytes, 0),
+		src,
+		dst,
+		txBytes: bytes,
+		rxBytes: 0,
+		txPkts: packets,
+		rxPkts: 0,
+		ports
+	};
+	if (directional) {
+		entry.directional = { protocolBytes, ports };
+	}
+	return entry;
+}
+
 // Manual retry with reset backoff
 export function retryLoadNetworkData() {
 	clearRetryState();
@@ -388,7 +454,7 @@ function convertAggregatedFlowsToNetworkLogs(flows: AggregatedFlow[], rangeStart
 	}
 
 	for (const flow of flows) {
-		const proto = flow.protocol || 0;
+		const directional = flow.directional === true;
 		if (flow.srcNodeId === flow.dstNodeId) {
 			// A self-pair is represented by one graph endpoint. Collapse both
 			// normalized directions into one TX-only entry so the graph does not
@@ -396,15 +462,28 @@ function convertAggregatedFlowsToNetworkLogs(flows: AggregatedFlow[], rangeStart
 			const totalBytes = (flow.totalTxBytes || 0) + (flow.totalRxBytes || 0);
 			if (totalBytes > 0) {
 				const selfLog = getOrCreateLog(flow.srcNodeId);
+				const protocolBytes = directional
+					? normalizeProtocolBytes(flow.txProtocolBytes, flow.protocol || 0, flow.totalTxBytes || 0)
+					: normalizeProtocolBytes(undefined, flow.protocol || 0, totalBytes);
+				if (directional) {
+					const reverseProtocolBytes = normalizeProtocolBytes(flow.rxProtocolBytes, flow.protocol || 0, flow.totalRxBytes || 0);
+					for (const [protocol, bytes] of Object.entries(reverseProtocolBytes)) {
+						protocolBytes[protocol] = (protocolBytes[protocol] || 0) + bytes;
+					}
+				}
+				const ports = directional
+					? mergePortStats(flow.txPorts, flow.rxPorts)
+					: flow.ports || [];
 				pushTraffic(selfLog, flow.trafficType, {
-					proto,
-					src: flow.srcNodeId,
-					dst: flow.dstNodeId,
-					txBytes: totalBytes,
-					rxBytes: 0,
-					txPkts: (flow.totalTxPkts || 0) + (flow.totalRxPkts || 0),
-					rxPkts: 0,
-					ports: flow.ports || []
+					...makeAggregateTrafficEntry(
+						flow.srcNodeId,
+						flow.dstNodeId,
+						totalBytes,
+						(flow.totalTxPkts || 0) + (flow.totalRxPkts || 0),
+						protocolBytes,
+						ports,
+						directional
+					)
 				});
 			}
 			continue;
@@ -413,34 +492,41 @@ function convertAggregatedFlowsToNetworkLogs(flows: AggregatedFlow[], rangeStart
 		// Forward direction: src sent txBytes to dst
 		if (flow.totalTxBytes > 0) {
 			const fwdLog = getOrCreateLog(flow.srcNodeId);
-			pushTraffic(fwdLog, flow.trafficType, {
-				proto,
-					src: flow.srcNodeId,
-					dst: flow.dstNodeId,
-					txBytes: flow.totalTxBytes,
-					rxBytes: 0,
-					txPkts: flow.totalTxPkts || 0,
-					rxPkts: 0,
-					ports: flow.ports || []
-			});
+			const protocolBytes = normalizeProtocolBytes(flow.txProtocolBytes, flow.protocol || 0, flow.totalTxBytes);
+			const ports = directional ? flow.txPorts || [] : flow.ports || [];
+			pushTraffic(
+				fwdLog,
+				flow.trafficType,
+				makeAggregateTrafficEntry(
+					flow.srcNodeId,
+					flow.dstNodeId,
+					flow.totalTxBytes,
+					flow.totalTxPkts || 0,
+					protocolBytes,
+					ports,
+					directional
+				)
+			);
 		}
 
 		// Reverse direction: dst sent rxBytes back to src
 		if (flow.totalRxBytes > 0) {
 			const revLog = getOrCreateLog(flow.dstNodeId);
-			pushTraffic(revLog, flow.trafficType, {
-				proto,
-				src: flow.dstNodeId,
-				dst: flow.srcNodeId,
-				txBytes: flow.totalRxBytes,
-				rxBytes: 0,
-				txPkts: flow.totalRxPkts || 0,
-				rxPkts: 0,
-				// Aggregated historical ports are not directional. Keep them on the
-				// forward entry only; copying the same list here falsely attributes
-				// destination/service ports to the reverse endpoint.
-				ports: []
-			});
+			const protocolBytes = normalizeProtocolBytes(flow.rxProtocolBytes, flow.protocol || 0, flow.totalRxBytes);
+			const ports = directional ? flow.rxPorts || [] : [];
+			pushTraffic(
+				revLog,
+				flow.trafficType,
+				makeAggregateTrafficEntry(
+					flow.dstNodeId,
+					flow.srcNodeId,
+					flow.totalRxBytes,
+					flow.totalRxPkts || 0,
+					protocolBytes,
+					ports,
+					directional
+				)
+			);
 		}
 	}
 

--- a/frontend/src/lib/stores/network-store.ts
+++ b/frontend/src/lib/stores/network-store.ts
@@ -416,10 +416,10 @@ function convertAggregatedFlowsToNetworkLogs(flows: AggregatedFlow[], rangeStart
 				rxBytes: 0,
 				txPkts: flow.totalRxPkts || 0,
 				rxPkts: 0,
-				// Aggregated historical flows have one combined top-port list.
-				// Preserve it on the reverse entry too so reverse-only traffic still
-				// exposes its port metadata to the graph and log viewer.
-				ports: flow.ports || []
+				// Aggregated historical ports are not directional. Keep them on the
+				// forward entry only; copying the same list here falsely attributes
+				// destination/service ports to the reverse endpoint.
+				ports: []
 			});
 		}
 	}

--- a/frontend/src/lib/stores/network-store.ts
+++ b/frontend/src/lib/stores/network-store.ts
@@ -245,7 +245,7 @@ export async function loadNetworkData(currentAttempt = 0) {
 
 	try {
 		if (get(dataSourceStore).followLatest) {
-			await dataSourceStore.fetchDataRange();
+			await dataSourceStore.fetchDataRange(signal);
 			if (signal.aborted) return;
 		}
 		const { start, end } = get(queryTimeWindow);

--- a/frontend/src/lib/stores/network-store.ts
+++ b/frontend/src/lib/stores/network-store.ts
@@ -389,16 +389,36 @@ function convertAggregatedFlowsToNetworkLogs(flows: AggregatedFlow[], rangeStart
 
 	for (const flow of flows) {
 		const proto = flow.protocol || 0;
+		if (flow.srcNodeId === flow.dstNodeId) {
+			// A self-pair is represented by one graph endpoint. Collapse both
+			// normalized directions into one TX-only entry so the graph does not
+			// render or count the same node twice.
+			const totalBytes = (flow.totalTxBytes || 0) + (flow.totalRxBytes || 0);
+			if (totalBytes > 0) {
+				const selfLog = getOrCreateLog(flow.srcNodeId);
+				pushTraffic(selfLog, flow.trafficType, {
+					proto,
+					src: flow.srcNodeId,
+					dst: flow.dstNodeId,
+					txBytes: totalBytes,
+					rxBytes: 0,
+					txPkts: (flow.totalTxPkts || 0) + (flow.totalRxPkts || 0),
+					rxPkts: 0,
+					ports: flow.ports || []
+				});
+			}
+			continue;
+		}
 
 		// Forward direction: src sent txBytes to dst
 		if (flow.totalTxBytes > 0) {
 			const fwdLog = getOrCreateLog(flow.srcNodeId);
 			pushTraffic(fwdLog, flow.trafficType, {
 				proto,
-				src: flow.srcNodeId,
-				dst: flow.dstNodeId,
-				txBytes: flow.totalTxBytes,
-				rxBytes: 0,
+					src: flow.srcNodeId,
+					dst: flow.dstNodeId,
+					txBytes: flow.totalTxBytes,
+					rxBytes: 0,
 					txPkts: flow.totalTxPkts || 0,
 					rxPkts: 0,
 					ports: flow.ports || []

--- a/frontend/src/lib/stores/network-store.ts
+++ b/frontend/src/lib/stores/network-store.ts
@@ -399,8 +399,9 @@ function convertAggregatedFlowsToNetworkLogs(flows: AggregatedFlow[], rangeStart
 				dst: flow.dstNodeId,
 				txBytes: flow.totalTxBytes,
 				rxBytes: 0,
-				txPkts: flow.totalTxPkts || 0,
-				rxPkts: 0
+					txPkts: flow.totalTxPkts || 0,
+					rxPkts: 0,
+					ports: flow.ports || []
 			});
 		}
 
@@ -413,8 +414,8 @@ function convertAggregatedFlowsToNetworkLogs(flows: AggregatedFlow[], rangeStart
 				dst: flow.srcNodeId,
 				txBytes: flow.totalRxBytes,
 				rxBytes: 0,
-				txPkts: flow.totalRxPkts || 0,
-				rxPkts: 0
+					txPkts: flow.totalRxPkts || 0,
+					rxPkts: 0
 			});
 		}
 	}

--- a/frontend/src/lib/stores/network-store.ts
+++ b/frontend/src/lib/stores/network-store.ts
@@ -414,8 +414,12 @@ function convertAggregatedFlowsToNetworkLogs(flows: AggregatedFlow[], rangeStart
 				dst: flow.srcNodeId,
 				txBytes: flow.totalRxBytes,
 				rxBytes: 0,
-					txPkts: flow.totalRxPkts || 0,
-					rxPkts: 0
+				txPkts: flow.totalRxPkts || 0,
+				rxPkts: 0,
+				// Aggregated historical flows have one combined top-port list.
+				// Preserve it on the reverse entry too so reverse-only traffic still
+				// exposes its port metadata to the graph and log viewer.
+				ports: flow.ports || []
 			});
 		}
 	}

--- a/frontend/src/lib/stores/policy-traffic-matcher.ts
+++ b/frontend/src/lib/stores/policy-traffic-matcher.ts
@@ -1,0 +1,186 @@
+import type { AccessEdgeMeta, PolicyGraph } from '$lib/policy-engine/types';
+import type { NetworkLink } from '$lib/types';
+
+const RELATION_TYPES = new Set(['member-of', 'owns-tag', 'contains', 'resolves-to']);
+
+export interface PolicyRuleMatch {
+	edgeType: string;
+	source: string;
+	target: string;
+	meta?: AccessEdgeMeta;
+	ruleIndex: number;
+}
+
+export interface DevicePolicyContextEntry {
+	groups: string[];
+	tagOwners: string[];
+	autogroups: string[];
+}
+
+export interface PolicyTrafficMatchContext {
+	graph: PolicyGraph | null;
+	groupMap: Map<string, string[]>;
+	deviceContext: Map<string, DevicePolicyContextEntry>;
+}
+
+interface ProtoPort {
+	proto?: string;
+	port?: number;
+	portEnd?: number;
+}
+
+function parseGrantIpSpecs(ipSpecs: string[]): ProtoPort[] {
+	return ipSpecs.map((spec) => {
+		if (spec === '*') return {};
+		const colonIdx = spec.indexOf(':');
+		if (colonIdx === -1) return { proto: spec.toLowerCase() };
+		const proto = spec.slice(0, colonIdx).trim().toLowerCase();
+		const portStr = spec.slice(colonIdx + 1);
+		if (!proto) return { proto: '__invalid__' };
+		if (portStr === '*') return { proto };
+		const range = portStr.split('-');
+		if (range.length > 2 || !range.every((part) => /^\d+$/.test(part))) {
+			return { proto: '__invalid__' };
+		}
+		const port = Number(range[0]);
+		const portEnd = range.length === 2 ? Number(range[1]) : port;
+		if (port < 1 || port > 65535 || portEnd < port || portEnd > 65535) {
+			return { proto: '__invalid__' };
+		}
+		return range.length === 2 ? { proto, port, portEnd } : { proto, port };
+	});
+}
+
+function matchesProtoPort(trafficProto: string, trafficPorts: Set<number>, allowed: ProtoPort[]): boolean {
+	for (const spec of allowed) {
+		if (!spec.proto && !spec.port) return true;
+		if (spec.proto && spec.proto !== '*' && spec.proto !== trafficProto) continue;
+		if (spec.port === undefined) return true;
+		for (const trafficPort of trafficPorts) {
+			if (spec.portEnd !== undefined) {
+				if (trafficPort >= spec.port && trafficPort <= spec.portEnd) return true;
+			} else if (trafficPort === spec.port) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+function portsOverlap(rulePorts: string[], trafficPorts: Set<number>): boolean {
+	for (const rulePort of rulePorts) {
+		if (rulePort === '*') return true;
+		const dashIdx = rulePort.indexOf('-');
+		if (dashIdx !== -1) {
+			const startText = rulePort.slice(0, dashIdx);
+			const endText = rulePort.slice(dashIdx + 1);
+			if (!/^\d+$/.test(startText) || !/^\d+$/.test(endText)) continue;
+			const start = Number(startText);
+			const end = Number(endText);
+			if (start < 1 || end < start || end > 65535) continue;
+			for (const trafficPort of trafficPorts) {
+				if (trafficPort >= start && trafficPort <= end) return true;
+			}
+		} else {
+			if (!/^\d+$/.test(rulePort)) continue;
+			const port = Number(rulePort);
+			if (port >= 1 && port <= 65535 && trafficPorts.has(port)) return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Match one graph link against policy access edges.
+ *
+ * This function is deliberately independent of Svelte stores so the direction
+ * and deduplication rules can be tested with deterministic fixtures.
+ */
+export function matchPolicyRulesForEdge(
+	edge: NetworkLink,
+	context: PolicyTrafficMatchContext,
+	srcTags: string[],
+	srcUser: string | undefined,
+	dstTags: string[],
+	dstUser: string | undefined,
+	srcIps: string[] = [],
+	dstIps: string[] = []
+): PolicyRuleMatch[] {
+	const { graph, groupMap, deviceContext } = context;
+	if (!graph) return [];
+
+	function addEffectiveGroups(selectors: Set<string>) {
+		const pending = [...selectors];
+		while (pending.length > 0) {
+			const member = pending.pop()!;
+			for (const group of groupMap.get(member) ?? []) {
+				if (!selectors.has(group)) {
+					selectors.add(group);
+					pending.push(group);
+				}
+			}
+		}
+	}
+
+	function buildSelectors(tags: string[], user: string | undefined, ips: string[]) {
+		const selectors = new Set<string>([...tags, ...(user ? [user] : []), '*']);
+		for (const ip of ips) {
+			const ctx = deviceContext.get(ip);
+			if (!ctx) continue;
+			for (const autogroup of ctx.autogroups) selectors.add(autogroup);
+			for (const group of ctx.groups) selectors.add(group);
+			for (const owner of ctx.tagOwners) selectors.add(owner);
+		}
+		addEffectiveGroups(selectors);
+		return selectors;
+	}
+
+	const matches: PolicyRuleMatch[] = [];
+	const matchedPolicyEdges = new Set<string>();
+	const observedDirections = edge.directions?.length
+		? edge.directions
+		: [{ source: edge.source, target: edge.target, protocol: edge.protocol, ports: edge.ports }];
+
+	for (const direction of observedDirections) {
+		const forward = direction.source === edge.source && direction.target === edge.target;
+		const directionSrcSelectors = buildSelectors(
+			forward ? srcTags : dstTags,
+			forward ? srcUser : dstUser,
+			forward ? srcIps : dstIps
+		);
+		const directionDstSelectors = buildSelectors(
+			forward ? dstTags : srcTags,
+			forward ? dstUser : srcUser,
+			forward ? dstIps : srcIps
+		);
+
+		for (const policyEdge of graph.edges) {
+			if (RELATION_TYPES.has(policyEdge.type)) continue;
+			if (!directionSrcSelectors.has(policyEdge.source) || !directionDstSelectors.has(policyEdge.target)) continue;
+			if (matchedPolicyEdges.has(policyEdge.id)) continue;
+
+			const meta = policyEdge.meta as AccessEdgeMeta | undefined;
+			if (policyEdge.type === 'grant') {
+				if (meta?.ip?.length && !matchesProtoPort(direction.protocol, direction.ports, parseGrantIpSpecs(meta.ip))) {
+					continue;
+				}
+			} else if (policyEdge.type === 'acl') {
+				if (meta?.proto && meta.proto !== '*' && direction.protocol && meta.proto !== direction.protocol) continue;
+				if (meta?.ports?.length && !meta.ports.includes('*') && !portsOverlap(meta.ports, direction.ports)) continue;
+			} else if (policyEdge.type === 'ssh') {
+				if (direction.protocol !== 'tcp' || !direction.ports.has(22)) continue;
+			}
+
+			matchedPolicyEdges.add(policyEdge.id);
+			matches.push({
+				edgeType: policyEdge.type,
+				source: policyEdge.source,
+				target: policyEdge.target,
+				meta,
+				ruleIndex: meta?.ruleRef?.index ?? -1
+			});
+		}
+	}
+
+	return matches;
+}

--- a/frontend/src/lib/stores/policy-traffic-store.test.ts
+++ b/frontend/src/lib/stores/policy-traffic-store.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+import { matchPolicyRulesForEdge } from './policy-traffic-matcher';
+import type { AccessEdgeMeta, GraphEdge, PolicyGraph } from '$lib/policy-engine/types';
+import type { NetworkLink, NetworkLog, TrafficEntry } from '$lib/types';
+import { processNetworkLogs } from '$lib/utils/network-processor';
+
+const SOURCE_NODE = 'client';
+const TARGET_NODE = 'server';
+const SOURCE_TAG = 'tag:clients';
+const TARGET_TAG = 'tag:servers';
+
+function accessEdge(
+	source: string,
+	target: string,
+	meta: Partial<AccessEdgeMeta> = {},
+	type: GraphEdge['type'] = 'grant'
+): GraphEdge {
+	return {
+		id: 'access:0',
+		type,
+		source,
+		target,
+		meta: {
+			ruleRef: { section: type === 'grant' ? 'grants' : 'acls', index: 0 },
+			...meta
+		}
+	};
+}
+
+function policyContext(...edges: GraphEdge[]) {
+	const graph: PolicyGraph = {
+		nodes: [],
+		edges,
+		nodeIdsBySelector: {},
+		warnings: []
+	};
+	return { graph, groupMap: new Map<string, string[]>(), deviceContext: new Map() };
+}
+
+function link(overrides: Partial<NetworkLink> = {}): NetworkLink {
+	return {
+		id: 'client<->server|virtual',
+		source: SOURCE_NODE,
+		target: TARGET_NODE,
+		originalSource: SOURCE_NODE,
+		originalTarget: TARGET_NODE,
+		totalBytes: 100,
+		txBytes: 100,
+		rxBytes: 0,
+		packets: 1,
+		protocol: 'tcp',
+		trafficType: 'virtual',
+		ports: new Set([443]),
+		...overrides
+	};
+}
+
+function direction(source: string, target: string, protocol: NetworkLink['protocol'], ports: number[]) {
+	return { source, target, protocol, ports: new Set(ports) };
+}
+
+function traffic(
+	src: string,
+	dst: string,
+	proto: number,
+	port: number,
+	bytes = 100,
+	directional = true
+): TrafficEntry {
+	return {
+		proto,
+		src,
+		dst,
+		txPkts: 1,
+		txBytes: bytes,
+		rxPkts: 0,
+		rxBytes: 0,
+		ports: [{ proto, port, bytes }],
+		...(directional
+			? { directional: { protocolBytes: { [proto]: bytes }, ports: [{ proto, port, bytes }] } }
+			: {})
+	};
+}
+
+function networkLog(nodeId: string, entry: TrafficEntry): NetworkLog {
+	return {
+		logged: '2026-01-01T00:00:00.000Z',
+		nodeId,
+		start: '2026-01-01T00:00:00.000Z',
+		end: '2026-01-01T00:01:00.000Z',
+		virtualTraffic: [entry],
+		subnetTraffic: [],
+		physicalTraffic: []
+	};
+}
+
+describe('directional policy matching', () => {
+	it('does not match a forward tcp:443 rule against reverse-only udp:53 traffic', () => {
+		const context = policyContext(accessEdge('*', '*', { ip: ['tcp:443'] }));
+
+		const matches = matchPolicyRulesForEdge(
+			link({
+				protocol: 'udp',
+				ports: new Set([53]),
+				directions: [direction(TARGET_NODE, SOURCE_NODE, 'udp', [53])]
+			}),
+			context,
+			[SOURCE_TAG],
+			undefined,
+			[TARGET_TAG],
+			undefined
+		);
+
+		expect(matches).toEqual([]);
+	});
+
+	it('matches a reverse selector using the observed reverse direction', () => {
+		const context = policyContext(accessEdge(TARGET_TAG, SOURCE_TAG, { ip: ['udp:53'] }));
+
+		const matches = matchPolicyRulesForEdge(
+			link({
+				protocol: 'udp',
+				ports: new Set([53]),
+				directions: [direction(TARGET_NODE, SOURCE_NODE, 'udp', [53])]
+			}),
+			context,
+			[SOURCE_TAG],
+			undefined,
+			[TARGET_TAG],
+			undefined
+		);
+
+		expect(matches).toHaveLength(1);
+		expect(matches[0]).toMatchObject({ source: TARGET_TAG, target: SOURCE_TAG });
+	});
+
+	it('matches a tag owner selector from device policy context', () => {
+		const owner = 'alice@example.com';
+		const context = policyContext(accessEdge(owner, TARGET_TAG, { ip: ['tcp:443'] }));
+		context.deviceContext.set('10.0.0.1', {
+			groups: [],
+			tagOwners: [owner],
+			autogroups: []
+		});
+
+		const matches = matchPolicyRulesForEdge(
+			link(),
+			context,
+			[],
+			undefined,
+			[TARGET_TAG],
+			undefined,
+			['10.0.0.1'],
+			['10.0.0.2']
+		);
+
+		expect(matches).toHaveLength(1);
+		expect(matches[0]).toMatchObject({ source: owner, target: TARGET_TAG });
+	});
+
+	it('keeps legacy aggregate links on their original source-to-target behavior', () => {
+		const context = policyContext(accessEdge(SOURCE_TAG, TARGET_TAG, { ip: ['tcp:443'] }));
+
+		const matches = matchPolicyRulesForEdge(
+			link({
+				protocol: 'tcp',
+				ports: new Set([443])
+			}),
+			context,
+			[SOURCE_TAG],
+			undefined,
+			[TARGET_TAG],
+			undefined
+		);
+
+		expect(matches).toHaveLength(1);
+	});
+
+	it('returns one policy edge when both observed directions match it', () => {
+		const context = policyContext(accessEdge('*', '*', { ip: ['tcp:443'] }));
+
+		const matches = matchPolicyRulesForEdge(
+			link({
+				directions: [
+					direction(SOURCE_NODE, TARGET_NODE, 'tcp', [443]),
+					direction(TARGET_NODE, SOURCE_NODE, 'tcp', [443])
+				]
+			}),
+			context,
+			[SOURCE_TAG],
+			undefined,
+			[TARGET_TAG],
+			undefined
+		);
+
+		expect(matches).toHaveLength(1);
+		expect(matches[0].source).toBe('*');
+	});
+
+	it('matches self-flow traffic without duplicating the policy edge', () => {
+		const context = policyContext(accessEdge('*', '*', { ip: ['tcp:443'] }));
+
+		const selfLink = link({
+			source: SOURCE_NODE,
+			target: SOURCE_NODE,
+			directions: [direction(SOURCE_NODE, SOURCE_NODE, 'tcp', [443])]
+		});
+		const matches = matchPolicyRulesForEdge(
+			selfLink,
+			context,
+			[SOURCE_TAG],
+			undefined,
+			[SOURCE_TAG],
+			undefined
+		);
+
+		expect(matches).toHaveLength(1);
+	});
+});
+
+describe('network processor direction metadata', () => {
+	it('preserves protocol and port observations separately for each direction', () => {
+		const processed = processNetworkLogs([
+			networkLog(SOURCE_NODE, traffic(SOURCE_NODE, TARGET_NODE, 6, 443)),
+			networkLog(TARGET_NODE, traffic(TARGET_NODE, SOURCE_NODE, 17, 53))
+		], []);
+
+		expect(processed.links).toHaveLength(1);
+		expect(processed.links[0].directions).toEqual([
+			direction(SOURCE_NODE, TARGET_NODE, 'tcp', [443]),
+			direction(TARGET_NODE, SOURCE_NODE, 'udp', [53])
+		]);
+	});
+
+	it('leaves legacy processor links without directional metadata', () => {
+		const processed = processNetworkLogs([
+			networkLog(SOURCE_NODE, traffic(SOURCE_NODE, TARGET_NODE, 6, 443, 100, false))
+		], []);
+
+		expect(processed.links).toHaveLength(1);
+		expect(processed.links[0].directions).toBeUndefined();
+		expect(processed.links[0].protocol).toBe('tcp');
+		expect(processed.links[0].ports).toEqual(new Set([443]));
+	});
+});

--- a/frontend/src/lib/stores/policy-traffic-store.ts
+++ b/frontend/src/lib/stores/policy-traffic-store.ts
@@ -279,42 +279,86 @@ export function matchPolicyRulesForEdge(
 	addEffectiveGroups(dstSelectors);
 
 	const matches: PolicyRuleMatch[] = [];
-	const trafficProto = edge.protocol; // 'tcp', 'udp', etc
-	const trafficPorts = edge.ports; // Set<number> of destination ports
+	const matchedPolicyEdges = new Set<string>();
+	const observedDirections = edge.directions?.length
+		? edge.directions
+		: [{ source: edge.source, target: edge.target, protocol: edge.protocol, ports: edge.ports }];
 
-	for (const pEdge of graph.edges) {
-		if (RELATION_TYPES.has(pEdge.type)) continue;
+	function selectorsForDirection(source: string, target: string) {
+		const sourceIsEdgeSource = source === edge.source && target === edge.target;
+		return {
+			sourceTags: sourceIsEdgeSource ? srcTags : dstTags,
+			sourceUser: sourceIsEdgeSource ? srcUser : dstUser,
+			sourceIps: sourceIsEdgeSource ? srcIps : dstIps,
+			targetTags: sourceIsEdgeSource ? dstTags : srcTags,
+			targetUser: sourceIsEdgeSource ? dstUser : srcUser,
+			targetIps: sourceIsEdgeSource ? dstIps : srcIps
+		};
+	}
 
-		if (!srcSelectors.has(pEdge.source) || !dstSelectors.has(pEdge.target)) continue;
-
-		const meta = pEdge.meta as AccessEdgeMeta | undefined;
-
-		if (pEdge.type === 'grant') {
-			// Grant rules use meta.ip for protocol:port specifiers
-			// ip: ["*"] = all traffic allowed
-			// ip: ["tcp:443", "tcp:8080"] = specific proto:port combos
-			if (meta?.ip?.length) {
-				const allowed = parseGrantIpSpecs(meta.ip);
-				if (!matchesProtoPort(trafficProto, trafficPorts, allowed)) continue;
-			}
-		} else if (pEdge.type === 'acl') {
-			// ACL rules: meta.proto for protocol, meta.ports for destination ports
-			// Check protocol match
-			if (meta?.proto && meta.proto !== '*' && trafficProto && meta.proto !== trafficProto) continue;
-			// Check port match
-			if (meta?.ports?.length && !meta.ports.includes('*') && !portsOverlap(meta.ports, trafficPorts)) continue;
-		} else if (pEdge.type === 'ssh') {
-			// SSH policy applies to TCP/22 only.
-			if (trafficProto !== 'tcp' || !trafficPorts.has(22)) continue;
+	function buildSelectors(tags: string[], user: string | undefined, ips: string[]) {
+		const selectors = new Set<string>([...tags, ...(user ? [user] : []), '*']);
+		for (const ip of ips) {
+			const ctx = devCtx.get(ip);
+			if (!ctx) continue;
+			for (const ag of ctx.autogroups) selectors.add(ag);
+			for (const g of ctx.groups) selectors.add(g);
 		}
+		addEffectiveGroups(selectors);
+		return selectors;
+	}
 
-		matches.push({
-			edgeType: pEdge.type,
-			source: pEdge.source,
-			target: pEdge.target,
-			meta,
-			ruleIndex: meta?.ruleRef?.index ?? -1
-		});
+	for (const direction of observedDirections) {
+		const directionSelectors = selectorsForDirection(direction.source, direction.target);
+		const directionSrcSelectors = buildSelectors(
+			directionSelectors.sourceTags,
+			directionSelectors.sourceUser,
+			directionSelectors.sourceIps || []
+		);
+		const directionDstSelectors = buildSelectors(
+			directionSelectors.targetTags,
+			directionSelectors.targetUser,
+			directionSelectors.targetIps || []
+		);
+		const trafficProto = direction.protocol;
+		const trafficPorts = direction.ports;
+
+		for (const pEdge of graph.edges) {
+			if (RELATION_TYPES.has(pEdge.type)) continue;
+
+			if (!directionSrcSelectors.has(pEdge.source) || !directionDstSelectors.has(pEdge.target)) continue;
+			if (matchedPolicyEdges.has(pEdge.id)) continue;
+
+			const meta = pEdge.meta as AccessEdgeMeta | undefined;
+
+			if (pEdge.type === 'grant') {
+				// Grant rules use meta.ip for protocol:port specifiers
+				// ip: ["*"] = all traffic allowed
+				// ip: ["tcp:443", "tcp:8080"] = specific proto:port combos
+				if (meta?.ip?.length) {
+					const allowed = parseGrantIpSpecs(meta.ip);
+					if (!matchesProtoPort(trafficProto, trafficPorts, allowed)) continue;
+				}
+			} else if (pEdge.type === 'acl') {
+				// ACL rules: meta.proto for protocol, meta.ports for destination ports
+				// Check protocol match
+				if (meta?.proto && meta.proto !== '*' && trafficProto && meta.proto !== trafficProto) continue;
+				// Check port match
+				if (meta?.ports?.length && !meta.ports.includes('*') && !portsOverlap(meta.ports, trafficPorts)) continue;
+			} else if (pEdge.type === 'ssh') {
+				// SSH policy applies to TCP/22 only.
+				if (trafficProto !== 'tcp' || !trafficPorts.has(22)) continue;
+			}
+
+			matchedPolicyEdges.add(pEdge.id);
+			matches.push({
+				edgeType: pEdge.type,
+				source: pEdge.source,
+				target: pEdge.target,
+				meta,
+				ruleIndex: meta?.ruleRef?.index ?? -1
+			});
+		}
 	}
 
 	return matches;

--- a/frontend/src/lib/stores/policy-traffic-store.ts
+++ b/frontend/src/lib/stores/policy-traffic-store.ts
@@ -159,15 +159,21 @@ function parseGrantIpSpecs(ipSpecs: string[]): ProtoPort[] {
 	return ipSpecs.map((spec) => {
 		if (spec === '*') return {};
 		const colonIdx = spec.indexOf(':');
-		if (colonIdx === -1) return { proto: spec };
-		const proto = spec.slice(0, colonIdx).toLowerCase();
+		if (colonIdx === -1) return { proto: spec.toLowerCase() };
+		const proto = spec.slice(0, colonIdx).trim().toLowerCase();
 		const portStr = spec.slice(colonIdx + 1);
+		if (!proto) return { proto: '__invalid__' };
 		if (portStr === '*') return { proto };
-		const dashIdx = portStr.indexOf('-');
-		if (dashIdx !== -1) {
-			return { proto, port: parseInt(portStr.slice(0, dashIdx)), portEnd: parseInt(portStr.slice(dashIdx + 1)) };
+		const range = portStr.split('-');
+		if (range.length > 2 || !range.every((part) => /^\d+$/.test(part))) {
+			return { proto: '__invalid__' };
 		}
-		return { proto, port: parseInt(portStr) };
+		const port = Number(range[0]);
+		const portEnd = range.length === 2 ? Number(range[1]) : port;
+		if (port < 1 || port > 65535 || portEnd < port || portEnd > 65535) {
+			return { proto: '__invalid__' };
+		}
+		return range.length === 2 ? { proto, port, portEnd } : { proto, port };
 	});
 }
 
@@ -175,10 +181,10 @@ function parseGrantIpSpecs(ipSpecs: string[]): ProtoPort[] {
 function matchesProtoPort(trafficProto: string, trafficPorts: Set<number>, allowed: ProtoPort[]): boolean {
 	for (const spec of allowed) {
 		if (!spec.proto && !spec.port) return true; // wildcard
-		if (spec.proto && spec.proto !== trafficProto) continue;
-		if (!spec.port) return true; // proto match, any port
+		if (spec.proto && spec.proto !== '*' && spec.proto !== trafficProto) continue;
+		if (spec.port === undefined) return true; // proto match, any port
 		for (const tp of trafficPorts) {
-			if (spec.portEnd) {
+			if (spec.portEnd !== undefined) {
 				if (tp >= spec.port && tp <= spec.portEnd) return true;
 			} else if (tp === spec.port) {
 				return true;
@@ -195,13 +201,19 @@ function portsOverlap(rulePorts: string[], trafficPorts: Set<number>): boolean {
 		if (rp === '*') return true;
 		const dashIdx = rp.indexOf('-');
 		if (dashIdx !== -1) {
-			const start = parseInt(rp.slice(0, dashIdx));
-			const end = parseInt(rp.slice(dashIdx + 1));
+			const startText = rp.slice(0, dashIdx);
+			const endText = rp.slice(dashIdx + 1);
+			if (!/^\d+$/.test(startText) || !/^\d+$/.test(endText)) continue;
+			const start = Number(startText);
+			const end = Number(endText);
+			if (start < 1 || end < start || end > 65535) continue;
 			for (const tp of trafficPorts) {
 				if (tp >= start && tp <= end) return true;
 			}
 		} else {
-			if (trafficPorts.has(parseInt(rp))) return true;
+			if (!/^\d+$/.test(rp)) continue;
+			const port = Number(rp);
+			if (port >= 1 && port <= 65535 && trafficPorts.has(port)) return true;
 		}
 	}
 	return false;
@@ -231,20 +243,22 @@ export function matchPolicyRulesForEdge(
 		...(dstUser ? [dstUser] : []),
 		'*'
 	]);
+	const groupMap = get(policyGroupMap);
+
+	function addEffectiveGroups(selectors: Set<string>) {
+		const pending = [...selectors];
+		while (pending.length > 0) {
+			const member = pending.pop()!;
+			for (const group of groupMap.get(member) ?? []) {
+				if (!selectors.has(group)) {
+					selectors.add(group);
+					pending.push(group);
+				}
+			}
+		}
+	}
 
 	// Add groups that these selectors belong to
-	const groupMap = get(policyGroupMap);
-	for (const sel of [...srcSelectors]) {
-		for (const group of groupMap.get(sel) ?? []) {
-			srcSelectors.add(group);
-		}
-	}
-	for (const sel of [...dstSelectors]) {
-		for (const group of groupMap.get(sel) ?? []) {
-			dstSelectors.add(group);
-		}
-	}
-
 	// Add autogroups from device context
 	const devCtx = get(devicePolicyContext);
 	for (const ip of srcIps ?? []) {
@@ -261,6 +275,8 @@ export function matchPolicyRulesForEdge(
 			for (const g of ctx.groups) dstSelectors.add(g);
 		}
 	}
+	addEffectiveGroups(srcSelectors);
+	addEffectiveGroups(dstSelectors);
 
 	const matches: PolicyRuleMatch[] = [];
 	const trafficProto = edge.protocol; // 'tcp', 'udp', etc
@@ -278,22 +294,19 @@ export function matchPolicyRulesForEdge(
 			// ip: ["*"] = all traffic allowed
 			// ip: ["tcp:443", "tcp:8080"] = specific proto:port combos
 			if (meta?.ip?.length) {
-				const hasWildcard = meta.ip.includes('*');
-				if (!hasWildcard && trafficPorts.size > 0) {
-					const allowed = parseGrantIpSpecs(meta.ip);
-					if (!matchesProtoPort(trafficProto, trafficPorts, allowed)) continue;
-				}
+				const allowed = parseGrantIpSpecs(meta.ip);
+				if (!matchesProtoPort(trafficProto, trafficPorts, allowed)) continue;
 			}
 		} else if (pEdge.type === 'acl') {
 			// ACL rules: meta.proto for protocol, meta.ports for destination ports
 			// Check protocol match
-			if (meta?.proto && trafficProto && meta.proto !== trafficProto) continue;
+			if (meta?.proto && meta.proto !== '*' && trafficProto && meta.proto !== trafficProto) continue;
 			// Check port match
-			if (meta?.ports?.length && trafficPorts.size > 0) {
-				if (!meta.ports.includes('*') && !portsOverlap(meta.ports, trafficPorts)) continue;
-			}
+			if (meta?.ports?.length && !meta.ports.includes('*') && !portsOverlap(meta.ports, trafficPorts)) continue;
+		} else if (pEdge.type === 'ssh') {
+			// SSH policy applies to TCP/22 only.
+			if (trafficProto !== 'tcp' || !trafficPorts.has(22)) continue;
 		}
-		// SSH rules: always match on port 22 implicitly, no port check needed
 
 		matches.push({
 			edgeType: pEdge.type,
@@ -328,6 +341,21 @@ function buildSelectorToNodeIds(
 ): Map<string, Set<string>> {
 	const map = new Map<string, Set<string>>();
 
+	function effectiveGroups(member: string): Set<string> {
+		const groups = new Set<string>();
+		const pending = [member];
+		while (pending.length > 0) {
+			const current = pending.pop()!;
+			for (const group of groupMap.get(current) ?? []) {
+				if (!groups.has(group)) {
+					groups.add(group);
+					pending.push(group);
+				}
+			}
+		}
+		return groups;
+	}
+
 	function addMapping(selector: string, nodeId: string) {
 		const set = map.get(selector) ?? new Set();
 		set.add(nodeId);
@@ -347,13 +375,13 @@ function buildSelectorToNodeIds(
 		addMapping('*', node.id);
 		// Groups (via user membership)
 		if (node.user) {
-			for (const group of groupMap.get(node.user) ?? []) {
+			for (const group of effectiveGroups(node.user)) {
 				addMapping(group, node.id);
 			}
 		}
 		// Groups (via tag membership)
 		for (const tag of node.tags ?? []) {
-			for (const group of groupMap.get(tag) ?? []) {
+			for (const group of effectiveGroups(tag)) {
 				addMapping(group, node.id);
 			}
 		}
@@ -366,6 +394,9 @@ function buildSelectorToNodeIds(
 			}
 			for (const g of ctx.groups) {
 				addMapping(g, node.id);
+				for (const group of effectiveGroups(g)) {
+					addMapping(group, node.id);
+				}
 			}
 		}
 	}

--- a/frontend/src/lib/stores/policy-traffic-store.ts
+++ b/frontend/src/lib/stores/policy-traffic-store.ts
@@ -1,8 +1,13 @@
 import { writable, derived, get } from 'svelte/store';
 import { policyGraph, tailnetUsers } from './policy-store';
 import { filteredEdges, filteredNodes, devices } from './network-store';
-import type { PolicyGraph, GraphEdge, AccessEdgeMeta } from '$lib/policy-engine/types';
+import type { PolicyGraph, GraphEdge } from '$lib/policy-engine/types';
 import type { NetworkLink, NetworkNode } from '$lib/types';
+import {
+	matchPolicyRulesForEdge as matchPolicyRulesForEdgePure,
+	type PolicyRuleMatch
+} from './policy-traffic-matcher';
+export type { PolicyRuleMatch } from './policy-traffic-matcher';
 
 // --- View Mode ---
 
@@ -10,14 +15,6 @@ export type ViewMode = 'traffic' | 'combined';
 export const viewMode = writable<ViewMode>('traffic');
 
 const RELATION_TYPES = new Set(['member-of', 'owns-tag', 'contains', 'resolves-to']);
-
-export interface PolicyRuleMatch {
-	edgeType: string;
-	source: string;
-	target: string;
-	meta?: AccessEdgeMeta;
-	ruleIndex: number;
-}
 
 // --- Policy context for nodes ---
 // Builds a complete picture of each entity's policy associations
@@ -146,79 +143,6 @@ export const devicePolicyContext = derived(
 // Backward compat — expose the simple group map for NetworkNode badges
 export const policyGroupMap = derived(policyRelations, ($rels) => $rels.memberOf);
 
-// --- Port/Protocol matching helpers ---
-
-interface ProtoPort {
-	proto?: string; // 'tcp', 'udp', or undefined for any
-	port?: number; // specific port, or undefined for any
-	portEnd?: number; // end of range if range specified
-}
-
-// Parse grant "ip" field specifiers like ["tcp:443", "udp:53", "*"]
-function parseGrantIpSpecs(ipSpecs: string[]): ProtoPort[] {
-	return ipSpecs.map((spec) => {
-		if (spec === '*') return {};
-		const colonIdx = spec.indexOf(':');
-		if (colonIdx === -1) return { proto: spec.toLowerCase() };
-		const proto = spec.slice(0, colonIdx).trim().toLowerCase();
-		const portStr = spec.slice(colonIdx + 1);
-		if (!proto) return { proto: '__invalid__' };
-		if (portStr === '*') return { proto };
-		const range = portStr.split('-');
-		if (range.length > 2 || !range.every((part) => /^\d+$/.test(part))) {
-			return { proto: '__invalid__' };
-		}
-		const port = Number(range[0]);
-		const portEnd = range.length === 2 ? Number(range[1]) : port;
-		if (port < 1 || port > 65535 || portEnd < port || portEnd > 65535) {
-			return { proto: '__invalid__' };
-		}
-		return range.length === 2 ? { proto, port, portEnd } : { proto, port };
-	});
-}
-
-// Check if traffic proto:port matches any of the allowed specs
-function matchesProtoPort(trafficProto: string, trafficPorts: Set<number>, allowed: ProtoPort[]): boolean {
-	for (const spec of allowed) {
-		if (!spec.proto && !spec.port) return true; // wildcard
-		if (spec.proto && spec.proto !== '*' && spec.proto !== trafficProto) continue;
-		if (spec.port === undefined) return true; // proto match, any port
-		for (const tp of trafficPorts) {
-			if (spec.portEnd !== undefined) {
-				if (tp >= spec.port && tp <= spec.portEnd) return true;
-			} else if (tp === spec.port) {
-				return true;
-			}
-		}
-	}
-	return false;
-}
-
-// Check if any ACL port spec overlaps with traffic ports
-// ACL ports are strings like "22", "443", "1024-65535", "*"
-function portsOverlap(rulePorts: string[], trafficPorts: Set<number>): boolean {
-	for (const rp of rulePorts) {
-		if (rp === '*') return true;
-		const dashIdx = rp.indexOf('-');
-		if (dashIdx !== -1) {
-			const startText = rp.slice(0, dashIdx);
-			const endText = rp.slice(dashIdx + 1);
-			if (!/^\d+$/.test(startText) || !/^\d+$/.test(endText)) continue;
-			const start = Number(startText);
-			const end = Number(endText);
-			if (start < 1 || end < start || end > 65535) continue;
-			for (const tp of trafficPorts) {
-				if (tp >= start && tp <= end) return true;
-			}
-		} else {
-			if (!/^\d+$/.test(rp)) continue;
-			const port = Number(rp);
-			if (port >= 1 && port <= 65535 && trafficPorts.has(port)) return true;
-		}
-	}
-	return false;
-}
-
 // Match a traffic edge against policy rules
 // Uses tag/user selectors from the traffic nodes rather than IP matching
 export function matchPolicyRulesForEdge(
@@ -230,138 +154,20 @@ export function matchPolicyRulesForEdge(
 	srcIps?: string[],
 	dstIps?: string[]
 ): PolicyRuleMatch[] {
-	const graph = get(policyGraph);
-	if (!graph) return [];
-
-	const srcSelectors = new Set<string>([
-		...srcTags,
-		...(srcUser ? [srcUser] : []),
-		'*'
-	]);
-	const dstSelectors = new Set<string>([
-		...dstTags,
-		...(dstUser ? [dstUser] : []),
-		'*'
-	]);
-	const groupMap = get(policyGroupMap);
-
-	function addEffectiveGroups(selectors: Set<string>) {
-		const pending = [...selectors];
-		while (pending.length > 0) {
-			const member = pending.pop()!;
-			for (const group of groupMap.get(member) ?? []) {
-				if (!selectors.has(group)) {
-					selectors.add(group);
-					pending.push(group);
-				}
-			}
-		}
-	}
-
-	// Add groups that these selectors belong to
-	// Add autogroups from device context
-	const devCtx = get(devicePolicyContext);
-	for (const ip of srcIps ?? []) {
-		const ctx = devCtx.get(ip);
-		if (ctx) {
-			for (const ag of ctx.autogroups) srcSelectors.add(ag);
-			for (const g of ctx.groups) srcSelectors.add(g);
-		}
-	}
-	for (const ip of dstIps ?? []) {
-		const ctx = devCtx.get(ip);
-		if (ctx) {
-			for (const ag of ctx.autogroups) dstSelectors.add(ag);
-			for (const g of ctx.groups) dstSelectors.add(g);
-		}
-	}
-	addEffectiveGroups(srcSelectors);
-	addEffectiveGroups(dstSelectors);
-
-	const matches: PolicyRuleMatch[] = [];
-	const matchedPolicyEdges = new Set<string>();
-	const observedDirections = edge.directions?.length
-		? edge.directions
-		: [{ source: edge.source, target: edge.target, protocol: edge.protocol, ports: edge.ports }];
-
-	function selectorsForDirection(source: string, target: string) {
-		const sourceIsEdgeSource = source === edge.source && target === edge.target;
-		return {
-			sourceTags: sourceIsEdgeSource ? srcTags : dstTags,
-			sourceUser: sourceIsEdgeSource ? srcUser : dstUser,
-			sourceIps: sourceIsEdgeSource ? srcIps : dstIps,
-			targetTags: sourceIsEdgeSource ? dstTags : srcTags,
-			targetUser: sourceIsEdgeSource ? dstUser : srcUser,
-			targetIps: sourceIsEdgeSource ? dstIps : srcIps
-		};
-	}
-
-	function buildSelectors(tags: string[], user: string | undefined, ips: string[]) {
-		const selectors = new Set<string>([...tags, ...(user ? [user] : []), '*']);
-		for (const ip of ips) {
-			const ctx = devCtx.get(ip);
-			if (!ctx) continue;
-			for (const ag of ctx.autogroups) selectors.add(ag);
-			for (const g of ctx.groups) selectors.add(g);
-		}
-		addEffectiveGroups(selectors);
-		return selectors;
-	}
-
-	for (const direction of observedDirections) {
-		const directionSelectors = selectorsForDirection(direction.source, direction.target);
-		const directionSrcSelectors = buildSelectors(
-			directionSelectors.sourceTags,
-			directionSelectors.sourceUser,
-			directionSelectors.sourceIps || []
-		);
-		const directionDstSelectors = buildSelectors(
-			directionSelectors.targetTags,
-			directionSelectors.targetUser,
-			directionSelectors.targetIps || []
-		);
-		const trafficProto = direction.protocol;
-		const trafficPorts = direction.ports;
-
-		for (const pEdge of graph.edges) {
-			if (RELATION_TYPES.has(pEdge.type)) continue;
-
-			if (!directionSrcSelectors.has(pEdge.source) || !directionDstSelectors.has(pEdge.target)) continue;
-			if (matchedPolicyEdges.has(pEdge.id)) continue;
-
-			const meta = pEdge.meta as AccessEdgeMeta | undefined;
-
-			if (pEdge.type === 'grant') {
-				// Grant rules use meta.ip for protocol:port specifiers
-				// ip: ["*"] = all traffic allowed
-				// ip: ["tcp:443", "tcp:8080"] = specific proto:port combos
-				if (meta?.ip?.length) {
-					const allowed = parseGrantIpSpecs(meta.ip);
-					if (!matchesProtoPort(trafficProto, trafficPorts, allowed)) continue;
-				}
-			} else if (pEdge.type === 'acl') {
-				// ACL rules: meta.proto for protocol, meta.ports for destination ports
-				// Check protocol match
-				if (meta?.proto && meta.proto !== '*' && trafficProto && meta.proto !== trafficProto) continue;
-				// Check port match
-				if (meta?.ports?.length && !meta.ports.includes('*') && !portsOverlap(meta.ports, trafficPorts)) continue;
-			} else if (pEdge.type === 'ssh') {
-				// SSH policy applies to TCP/22 only.
-				if (trafficProto !== 'tcp' || !trafficPorts.has(22)) continue;
-			}
-
-			matchedPolicyEdges.add(pEdge.id);
-			matches.push({
-				edgeType: pEdge.type,
-				source: pEdge.source,
-				target: pEdge.target,
-				meta,
-				ruleIndex: meta?.ruleRef?.index ?? -1
-			});
-		}
-	}
-
-	return matches;
+	return matchPolicyRulesForEdgePure(
+		edge,
+		{
+			graph: get(policyGraph),
+			groupMap: get(policyGroupMap),
+			deviceContext: get(devicePolicyContext)
+		},
+		srcTags,
+		srcUser,
+		dstTags,
+		dstUser,
+		srcIps,
+		dstIps
+	);
 }
 
 // --- Combined Mode: Policy overlay edges for the traffic graph ---

--- a/frontend/src/lib/stores/stats-store.ts
+++ b/frontend/src/lib/stores/stats-store.ts
@@ -99,6 +99,7 @@ export async function loadStats(currentAttempt = 0) {
 					udpBytes: 0,
 					otherProtoBytes: 0,
 					virtualBytes: 0,
+					exitBytes: 0,
 					subnetBytes: 0,
 					physicalBytes: 0,
 					totalFlows: 0,

--- a/frontend/src/lib/stores/stats-store.ts
+++ b/frontend/src/lib/stores/stats-store.ts
@@ -86,7 +86,7 @@ export async function loadStats(currentAttempt = 0) {
 
 	try {
 		if (get(dataSourceStore).followLatest) {
-			await dataSourceStore.fetchDataRange();
+			await dataSourceStore.fetchDataRange(signal);
 			if (signal.aborted) return;
 		}
 		const { start, end } = get(queryTimeWindow);

--- a/frontend/src/lib/stores/stats-store.ts
+++ b/frontend/src/lib/stores/stats-store.ts
@@ -173,6 +173,11 @@ export function stopStatsRefresh() {
 		clearInterval(refreshTimer);
 		refreshTimer = null;
 	}
+	if (statsController) {
+		statsController.abort();
+		statsController = null;
+	}
+	clearStatsRetryState();
 }
 
 export const statsSummary = derived(statsState, ($s) => $s.summary);
@@ -202,7 +207,7 @@ export const topPorts = derived(statsState, ($s): PortStat[] => {
 		}
 	}
 	return Array.from(portMap.values())
-		.sort((a, b) => b.bytes - a.bytes)
+		.sort((a, b) => b.bytes - a.bytes || a.proto - b.proto || a.port - b.port)
 		.slice(0, 15);
 });
 

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -26,6 +26,9 @@ export interface TrafficEntry {
 	txBytes: number;
 	rxPkts?: number;
 	rxBytes?: number;
+	// Aggregated historical flows may carry destination port totals directly
+	// because they no longer contain one raw event per port.
+	ports?: PortStat[];
 }
 
 export interface NetworkLog {

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -119,6 +119,7 @@ export interface TrafficStatsBucket {
 	udpBytes: number;
 	otherProtoBytes: number;
 	virtualBytes: number;
+	exitBytes: number;
 	subnetBytes: number;
 	physicalBytes: number;
 	totalFlows: number;
@@ -131,6 +132,7 @@ export interface TrafficStatsSummary {
 	udpBytes: number;
 	otherProtoBytes: number;
 	virtualBytes: number;
+	exitBytes: number;
 	subnetBytes: number;
 	physicalBytes: number;
 	totalFlows: number;

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -29,6 +29,14 @@ export interface TrafficEntry {
 	// Aggregated historical flows may carry destination port totals directly
 	// because they no longer contain one raw event per port.
 	ports?: PortStat[];
+	// Directional aggregate metadata is present only for aggregate flows whose
+	// protocol and destination-port observations were preserved by direction.
+	directional?: DirectionalTrafficMetadata;
+}
+
+export interface DirectionalTrafficMetadata {
+	protocolBytes?: Record<string, number>;
+	ports?: PortStat[];
 }
 
 export interface NetworkLog {
@@ -79,6 +87,16 @@ export interface NetworkLink {
 	packets: number;
 	protocol: Protocol;
 	trafficType: TrafficType;
+	ports: Set<number>;
+	// Historical aggregate flows may retain separate observations for each
+	// direction. Legacy/live entries leave this unset and use the fields above.
+	directions?: NetworkLinkDirection[];
+}
+
+export interface NetworkLinkDirection {
+	source: string;
+	target: string;
+	protocol: Protocol;
 	ports: Set<number>;
 }
 

--- a/frontend/src/lib/utils/ip-utils.ts
+++ b/frontend/src/lib/utils/ip-utils.ts
@@ -3,7 +3,7 @@ export function extractIP(address: string): string {
 	//Guard Against Null Values
 	if (!address) return '';
 	// Handle IPv6 addresses like [fd7a:115c:a1e0::9001:b818]:62574
-	if (address.startsWith('[') && address.includes(']:')) {
+	if (address.startsWith('[') && address.includes(']:') && extractPort(address) !== null) {
 		return address.substring(1, address.indexOf(']:'));
 	}
 
@@ -11,13 +11,18 @@ export function extractIP(address: string): string {
 	// IPv4 has exactly 3 dots, so we can safely split on last colon
 	if (!address.includes('::') && (address.match(/\./g) || []).length === 3) {
 		const colonIndex = address.lastIndexOf(':');
-		if (colonIndex > 0) {
+		if (colonIndex > 0 && isValidIPv4(address.substring(0, colonIndex)) && extractPort(address) !== null) {
 			return address.substring(0, colonIndex);
 		}
 	}
 
 	// For IPv6 without brackets, return as-is (port should be in bracket format)
 	return address;
+}
+
+function isValidIPv4(address: string): boolean {
+	const parts = address.split('.');
+	return parts.length === 4 && parts.every((part) => /^\d+$/.test(part) && Number(part) >= 0 && Number(part) <= 255);
 }
 
 // Extract port from address:port string
@@ -31,6 +36,8 @@ export function extractPort(address: string): number | null {
 	};
 	// Handle IPv6 addresses like [fd7a:115c:a1e0::9001:b818]:62574
 	if (address.startsWith('[') && address.includes(']:')) {
+		const host = address.substring(1, address.indexOf(']:'));
+		if (!isValidIPv6Literal(host)) return null;
 		const suffix = address.slice(address.indexOf(']:') + 2);
 		return parsePort(suffix);
 	}
@@ -48,6 +55,19 @@ export function extractPort(address: string): number | null {
 	}
 
 	return null;
+}
+
+function isValidIPv6Literal(address: string): boolean {
+	const parts = address.split('::');
+	if (parts.length > 2) return false;
+	const validGroup = (group: string) => /^[0-9a-fA-F]{1,4}$/.test(group);
+	if (parts.length === 1) {
+		const groups = address.split(':');
+		return groups.length === 8 && groups.every(validGroup);
+	}
+	const left = parts[0] ? parts[0].split(':') : [];
+	const right = parts[1] ? parts[1].split(':') : [];
+	return left.length + right.length < 8 && [...left, ...right].every(validGroup);
 }
 
 // Categorize IP addresses by type

--- a/frontend/src/lib/utils/ip-utils.ts
+++ b/frontend/src/lib/utils/ip-utils.ts
@@ -24,10 +24,15 @@ export function extractIP(address: string): string {
 export function extractPort(address: string): number | null {
 	//Guard Against Null Values
 	if (!address) return null;
+	const parsePort = (raw: string): number | null => {
+		if (!/^\d+$/.test(raw)) return null;
+		const port = Number(raw);
+		return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null;
+	};
 	// Handle IPv6 addresses like [fd7a:115c:a1e0::9001:b818]:62574
 	if (address.startsWith('[') && address.includes(']:')) {
-		const portStr = address.split(']:')[1];
-		return portStr ? parseInt(portStr, 10) : null;
+		const suffix = address.slice(address.indexOf(']:') + 2);
+		return parsePort(suffix);
 	}
 
 	// IPv6 addresses without brackets have no port (port requires bracket notation)
@@ -38,10 +43,8 @@ export function extractPort(address: string): number | null {
 
 	// Handle IPv4 addresses like 100.72.184.20:53221
 	if (address.includes(':')) {
-		const portStr = address.split(':').pop();
-		const port = portStr ? parseInt(portStr, 10) : null;
-		// Ensure we got a valid port number
-		return port !== null && !isNaN(port) ? port : null;
+		const portStr = address.slice(address.lastIndexOf(':') + 1);
+		return parsePort(portStr);
 	}
 
 	return null;

--- a/frontend/src/lib/utils/network-processor.ts
+++ b/frontend/src/lib/utils/network-processor.ts
@@ -313,11 +313,17 @@ export function processNetworkLogs(
 			const srcNode = nodeMap.get(srcNodeId)!;
 			const dstNode = nodeMap.get(dstNodeId)!;
 
-			// txBytes always represents what the src sent to dst
-			srcNode.txBytes += traffic.txBytes || 0;
-			dstNode.rxBytes += traffic.txBytes || 0;
-			srcNode.totalBytes = srcNode.txBytes + srcNode.rxBytes;
-			dstNode.totalBytes = dstNode.txBytes + dstNode.rxBytes;
+			// txBytes always represents what the src sent to dst. A self-flow has
+			// one graph node, so do not also add the same bytes as RX.
+			if (srcNodeId === dstNodeId) {
+				srcNode.txBytes += traffic.txBytes || 0;
+				srcNode.totalBytes = srcNode.txBytes + srcNode.rxBytes;
+			} else {
+				srcNode.txBytes += traffic.txBytes || 0;
+				dstNode.rxBytes += traffic.txBytes || 0;
+				srcNode.totalBytes = srcNode.txBytes + srcNode.rxBytes;
+				dstNode.totalBytes = dstNode.txBytes + dstNode.rxBytes;
+			}
 
 			// Track port and protocol information
 			const protocolName = getProtocolName(traffic.proto || 0);
@@ -387,7 +393,7 @@ export function processNetworkLogs(
 		const srcNode = nodeMap.get(link.source);
 		const dstNode = nodeMap.get(link.target);
 		if (srcNode) srcNode.connections++;
-		if (dstNode) dstNode.connections++;
+		if (dstNode && dstNode.id !== srcNode?.id) dstNode.connections++;
 	});
 
 	return {

--- a/frontend/src/lib/utils/network-processor.ts
+++ b/frontend/src/lib/utils/network-processor.ts
@@ -132,6 +132,37 @@ function resolveToIP(ipOrId: string, devices: Device[] = []): string {
 	return ipOrId;
 }
 
+// Resolve a flow endpoint to a stable graph identity. Display names are
+// presentation data and are not unique (two devices may share a hostname),
+// so they must never be used as node IDs.
+function resolveToNodeID(
+	ipOrId: string,
+	devices: Device[] = [],
+	services: Record<string, VIPServiceInfo> = {},
+	records: Record<string, StaticRecordInfo> = {}
+): string {
+	if (!isIPAddress(ipOrId)) {
+		return devices.find((device) => device.id === ipOrId)?.id || ipOrId;
+	}
+
+	const ip = extractIP(ipOrId);
+	const device = devices.find((candidate) => candidate.addresses.some((addr) => ipMatches(ip, addr)));
+	if (device) return device.id;
+
+	for (const [serviceName, serviceInfo] of Object.entries(services)) {
+		if (serviceInfo.addrs?.some((addr) => ipMatches(ip, addr))) {
+			return serviceName.startsWith('svc:') ? serviceName : `svc:${serviceName}`;
+		}
+	}
+	for (const [recordName, recordInfo] of Object.entries(records)) {
+		if (recordInfo.addrs?.some((addr) => ipMatches(ip, addr))) {
+			return `record:${recordName}`;
+		}
+	}
+
+	return ip;
+}
+
 // Process network logs to create nodes and links
 export function processNetworkLogs(
 	logs: NetworkLog[],
@@ -147,9 +178,6 @@ export function processNetworkLogs(
 	const linkMap = new Map<string, NetworkLink>();
 
 	logs.forEach((log) => {
-		// Resolve the reporting node's identity for proper byte attribution
-		const reporterIP = resolveToIP(log.nodeId, devices);
-
 		const allTraffic = [
 			...(log.virtualTraffic || []).map((t) => ({ ...t, type: 'virtual' as TrafficType })),
 			...(log.exitTraffic || []).map((t) => ({ ...t, type: 'exit' as TrafficType })),
@@ -172,13 +200,13 @@ export function processNetworkLogs(
 
 			// Create or update source node
 			const srcDeviceName = getDeviceName(traffic.src, devices, services, records);
-			const srcNodeId = isOpaqueTailscaleNodeID(traffic.src) ? traffic.src : (srcDeviceName !== srcIP ? srcDeviceName : srcIP);
+			const srcNodeId = resolveToNodeID(traffic.src, devices, services, records);
 
 			if (!nodeMap.has(srcNodeId)) {
 				const srcAddress = displayAddress(srcIP);
-				const isTailscale = srcAddress ? categorizeIP(srcAddress).includes('tailscale') : false;
 				const deviceData = getDeviceData(traffic.src, devices);
 				const serviceData = getServiceData(traffic.src, services);
+				const isTailscale = !!deviceData || (srcAddress ? categorizeIP(srcAddress).includes('tailscale') : false);
 				const ipTags = srcAddress ? categorizeIP(srcAddress) : (isOpaqueTailscaleNodeID(traffic.src) ? ['unresolved'] : []);
 				const deviceTags = deviceData?.tags || [];
 				const serviceTags = serviceData?.tags || [];
@@ -226,13 +254,13 @@ export function processNetworkLogs(
 
 			// Create or update destination node
 			const dstDeviceName = getDeviceName(traffic.dst, devices, services, records);
-			const dstNodeId = isOpaqueTailscaleNodeID(traffic.dst) ? traffic.dst : (dstDeviceName !== dstIP ? dstDeviceName : dstIP);
+			const dstNodeId = resolveToNodeID(traffic.dst, devices, services, records);
 
 			if (!nodeMap.has(dstNodeId)) {
 				const dstAddress = displayAddress(dstIP);
-				const isTailscale = dstAddress ? categorizeIP(dstAddress).includes('tailscale') : false;
 				const deviceData = getDeviceData(traffic.dst, devices);
 				const serviceData = getServiceData(traffic.dst, services);
+				const isTailscale = !!deviceData || (dstAddress ? categorizeIP(dstAddress).includes('tailscale') : false);
 				const ipTags = dstAddress ? categorizeIP(dstAddress) : (isOpaqueTailscaleNodeID(traffic.dst) ? ['unresolved'] : []);
 				const deviceTags = deviceData?.tags || [];
 				const serviceTags = serviceData?.tags || [];
@@ -312,6 +340,9 @@ export function processNetworkLogs(
 					dstNode.incomingPorts.add(dstPort);
 				}
 			}
+			for (const port of traffic.ports || []) {
+				if (port.port > 0) dstNode.incomingPorts.add(port.port);
+			}
 
 			// Create or update link - use bidirectional key to combine A->B and B->A
 			const sortedIds = [srcNodeId, dstNodeId].sort();
@@ -337,6 +368,9 @@ export function processNetworkLogs(
 			// TX-only link accounting: attribute txBytes based on direction relative
 			// to the sorted link key. This avoids double-counting when both endpoints report.
 			const link = linkMap.get(linkKey)!;
+			for (const port of traffic.ports || []) {
+				if (port.port > 0) link.ports.add(port.port);
+			}
 			const isSrcFirst = srcNodeId === sortedIds[0];
 			if (isSrcFirst) {
 				link.txBytes += traffic.txBytes || 0;

--- a/frontend/src/lib/utils/network-processor.ts
+++ b/frontend/src/lib/utils/network-processor.ts
@@ -163,6 +163,47 @@ function resolveToNodeID(
 	return ip;
 }
 
+function addDirectionalObservation(
+	link: NetworkLink,
+	source: string,
+	target: string,
+	protocol: ReturnType<typeof getProtocolName>,
+	ports: Set<number>
+) {
+	if (!link.directions) link.directions = [];
+
+	const existing = link.directions.find(
+		(direction) =>
+			direction.source === source && direction.target === target && direction.protocol === protocol
+	);
+	if (existing) {
+		for (const port of ports) existing.ports.add(port);
+		return;
+	}
+
+	link.directions.push({ source, target, protocol, ports: new Set(ports) });
+}
+
+function addDirectionalTraffic(link: NetworkLink, traffic: NetworkLog['virtualTraffic'][number], source: string, target: string) {
+	const protocolNumbers = new Set<number>();
+	for (const rawProtocol of Object.keys(traffic.directional?.protocolBytes || {})) {
+		const protocol = Number(rawProtocol);
+		if (Number.isInteger(protocol) && protocol >= 0) protocolNumbers.add(protocol);
+	}
+	for (const port of traffic.directional?.ports || []) {
+		if (Number.isInteger(port.proto) && port.proto >= 0) protocolNumbers.add(port.proto);
+	}
+	if (protocolNumbers.size === 0) protocolNumbers.add(traffic.proto || 0);
+
+	for (const protocolNumber of protocolNumbers) {
+		const ports = new Set<number>();
+		for (const port of traffic.directional?.ports || []) {
+			if (port.port > 0 && port.proto === protocolNumber) ports.add(port.port);
+		}
+		addDirectionalObservation(link, source, target, getProtocolName(protocolNumber), ports);
+	}
+}
+
 // Process network logs to create nodes and links
 export function processNetworkLogs(
 	logs: NetworkLog[],
@@ -376,6 +417,9 @@ export function processNetworkLogs(
 			const link = linkMap.get(linkKey)!;
 			for (const port of traffic.ports || []) {
 				if (port.port > 0) link.ports.add(port.port);
+			}
+			if (traffic.directional) {
+				addDirectionalTraffic(link, traffic, srcNodeId, dstNodeId);
 			}
 			const isSrcFirst = srcNodeId === sortedIds[0];
 			if (isSrcFirst) {

--- a/frontend/src/routes/analytics/+page.svelte
+++ b/frontend/src/routes/analytics/+page.svelte
@@ -139,6 +139,7 @@
 		if (!s) return [];
 		return [
 			{ label: 'Virtual', value: s.virtualBytes, color: 'var(--color-traffic-virtual)' },
+			{ label: 'Exit Node', value: s.exitBytes, color: 'var(--color-traffic-exit)' },
 			{ label: 'Subnet', value: s.subnetBytes, color: 'var(--color-traffic-subnet)' },
 			{ label: 'Physical', value: s.physicalBytes, color: 'var(--color-traffic-physical)' }
 		];
@@ -162,7 +163,7 @@
 		// Use protocol breakdown when available, otherwise fall back to traffic type totals
 		const protoTotal = $statsSummary.tcpBytes + $statsSummary.udpBytes + $statsSummary.otherProtoBytes;
 		if (protoTotal > 0) return protoTotal;
-		return $statsSummary.virtualBytes + $statsSummary.subnetBytes;
+		return $statsSummary.virtualBytes + $statsSummary.exitBytes + $statsSummary.subnetBytes + $statsSummary.physicalBytes;
 	});
 
 	const timeWindowLabel = $derived.by(() => {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	resolve: {
+		alias: {
+			$lib: fileURLToPath(new URL('./src/lib', import.meta.url))
+		}
+	},
+	test: {
+		environment: 'node',
+		include: ['src/**/*.test.ts']
+	}
+});

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -141,4 +141,5 @@ spec:
               cpu: "1000m"
       volumes:
         - name: data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: tsflow-data

--- a/k8s/httproute.yaml
+++ b/k8s/httproute.yaml
@@ -15,7 +15,7 @@ spec:
         - group: ""
           kind: Service
           name: tsflow
-          port: 8080
+          port: 80
           weight: 1
       matches:
         - path:

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - deployment.yaml
+  - pvc.yaml
   - service.yaml
   - httproute.yaml
   - secret.yaml

--- a/k8s/pvc.yaml
+++ b/k8s/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tsflow-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
## Summary

- harden configuration, API/object-store selection, URL/port validation, shutdown, cancellation, and production CORS
- make aggregate ingestion/querying robust across ranges, polls, cache updates, protocol bytes, ports, and object-store cursors
- deprecate raw historical-flow routes with actionable `410 Gone` responses
- stabilize historical graph identities and harden policy parsing/matching, including nested groups and validated ports
- add focused backend regression coverage and make CI binary verification fail on real errors

## Validation

- `cd backend && go test -count=1 -tags exclude_frontend ./...`
- `cd backend && go test -race -tags exclude_frontend ./...`
- `cd backend && go vet -tags exclude_frontend ./...`
- `cd frontend && npm run check`
- `cd frontend && npm run build`
- `git diff --check`
